### PR TITLE
Default settings get type specified for the setting rather than their own type

### DIFF
--- a/docs/source/content/casefiles.rst
+++ b/docs/source/content/casefiles.rst
@@ -18,6 +18,7 @@ A typical way to assemble the solver configuration file is to place all your des
 in a dictionary and then convert to and write your ``ConfigObj``. If a setting is not provided the default value will be used. The settings that each solver takes, its type and default value are explained in their relevant documentation pages.
 
 .. code-block:: python
+
     import configobj
     filename = '<case_route>/<case_name>.sharpy'
     config = configobj.ConfigObj()

--- a/docs/source/content/casefiles.rst
+++ b/docs/source/content/casefiles.rst
@@ -14,6 +14,31 @@ to run them.
 
 .. _ConfigObj: http://pypi.org/project/configobj/
 
+A typical way to assemble the solver configuration file is to place all your desired settings
+in a dictionary and then convert to and write your ``ConfigObj``. If a setting is not provided the default value will be used. The settings that each solver takes, its type and default value are explained in their relevant documentation pages.
+
+.. code-block:: python
+    import configobj
+    filename = '<case_route>/<case_name>.sharpy'
+    config = configobj.ConfigObj()
+    config.filename = filename
+    config['SHARPy'] = {'case': '<your SHARPy case name>',  # an example setting
+                        # Rest of your settings for the PreSHARPy class
+                        }
+    config['BeamLoader'] = {'orientation': [1., 0., 0.],  # an example setting
+                            # Rest of settings for the BeamLoader solver
+                            }
+    # Continue as above for the remainder of solvers that you would like to include
+
+    # finally, write the config file
+    config.write()
+
+The resulting ``.sharpy`` file is a plain text file with your specified settings for each of
+the solvers.
+
+Note that, therefore, if one of your settings is a ``np.array``, it will get transformed into
+a string of plain text before being read by SHARPy. However, any setting with ``list(float)`` specified as its setting type will get converted into a ``np.array`` once it is read by SHARPy.
+
 
 FEM file
 --------

--- a/docs/source/content/solvers.rst
+++ b/docs/source/content/solvers.rst
@@ -1,7 +1,11 @@
 SHARPy Solvers
 ------------------
 
-``SHARPy`` has the following solvers available for use:
+The available SHARPy solvers are listed below. Attending to SHARPy's modular structure, they can be run
+independently so the order in which you desire to run them is important.
+
+The starting point is the PreSharpy loader. It contains the simulation configuration and which solvers are to be run
+and in the order that should happen.
 
 .. toctree::
     :glob:

--- a/docs/source/includes/solvers/loader/PreSharpy.rst
+++ b/docs/source/includes/solvers/loader/PreSharpy.rst
@@ -1,0 +1,7 @@
+PreSharpy
+---------
+
+
+
+.. autoclass:: sharpy.presharpy.presharpy.PreSharpy
+	:members:

--- a/docs/source/includes/solvers/loader_solvers.rst
+++ b/docs/source/includes/solvers/loader_solvers.rst
@@ -2,5 +2,6 @@ Loader Solvers
 ++++++++++++++
 
 .. toctree::
+    ./loader/PreSharpy
     ./loader/AerogridLoader
     ./loader/BeamLoader

--- a/sharpy/generators/gustvelocityfield.py
+++ b/sharpy/generators/gustvelocityfield.py
@@ -82,11 +82,11 @@ class one_minus_cos(BaseGust):
 
     settings_types['gust_length'] = 'float'
     settings_default['gust_length'] = 0.0
-    settings_description['gust_length'] = 'Length of gust'
+    settings_description['gust_length'] = 'Length of gust, :math:`S`.'
 
     settings_types['gust_intensity'] = 'float'
     settings_default['gust_intensity'] = 0.0
-    settings_description['gust_intensity'] = 'Intensity of the gust'
+    settings_description['gust_intensity'] = 'Intensity of the gust :math:`u_{de}`.'
 
     setting_table = settings.SettingsTable()
     __doc__ += setting_table.generate(settings_types, settings_default, settings_description, doc_settings_description)

--- a/sharpy/linear/assembler/linearaeroelastic.py
+++ b/sharpy/linear/assembler/linearaeroelastic.py
@@ -254,7 +254,7 @@ class LinearAeroelastic(ss_interface.BaseElement):
         # Save zero force reference
         self.linearisation_vectors['forces_aero_beam_dof'] = Ksa.dot(self.linearisation_vectors['forces_aero'])
 
-        if self.settings['beam_settings']['modal_projection'] == True and \
+        if self.settings['beam_settings']['modal_projection'] is True and \
                 self.settings['beam_settings']['inout_coords'] == 'modes':
             self.linearisation_vectors['forces_aero_beam_dof'] = out_mode_matrix.dot(self.linearisation_vectors['forces_aero_beam_dof'])
 

--- a/sharpy/presharpy/presharpy.py
+++ b/sharpy/presharpy/presharpy.py
@@ -10,40 +10,60 @@ import sharpy.utils.exceptions as exceptions
 @solver
 class PreSharpy(object):
     """
-    The main class for preSHARPy.
+    The PreSharpy solver is the main loader solver of SHARPy. It takes the admin-like settings for the simulation,
+    including the case name, case route and the list of solvers to run and in which order to run them. This order
+    of solvers is referred to, throughout SHARPy, as the ``flow`` setting.
 
-    PreSharpy objects contain information on the output of the problem.
-    The ``PreSharpy`` ``settings`` attributes are obtained from the ``.solver.txt`` file, under ``[SHARPy]``.
+    This is a mandatory solver for all simulations at the start so it is never included in the ``flow`` setting.
 
-    Args:
-        in_settings: settings file, from which ``[SHARPy]`` values are extracted
+    The settings for this solver are parsed through in the configuration file under the header ``SHARPy``. I.e, when
+    you are defining the config file for a simulation, the settings for PreSharpy are included as:
 
-    Attributes:
-        settings (dict): name-value pairs of solution settings types.
-            See Notes for acceptable combinations.
-        settings_types (dict): accepted types for values in ``settings``
-        settings_default (dict): default values for ``settings``, should none be provided.
-        ts (int): solution time step
-        case_route (str): route to case folder
-        case_name (str): name of the case
+    .. code-block:: python
 
-    Notes:
+        import configobj
+        filename = '<case_route>/<case_name>.sharpy'
+        config = configobj.ConfigObj()
+        config.filename = filename
+        config['SHARPy'] = {'case': '<your SHARPy case name>',  # an example setting
+                            # Rest of your settings for the PreSHARPy class
+                            }
 
-        The following key-value pairs are acceptable ``settings`` for the ``PreSharpy`` class:
-
-        ================  =============  ===============================================  =====================
-        Key               Type           Description                                      Default
-        ================  =============  ===============================================  =====================
-        ``flow``          ``list(str)``  List of solvers to run in the appropriate order  ``None``
-        ``case``          ``str``        Case name                                        ``default_case_name``
-        ``route``         ``str``        Route to folder                                  ``None``
-        ``write_screen``  ``bool``       Write output to terminal screen                  ``True``
-        ``write_log``     ``bool``       Write log file to output folder                  ``False``
-        ``log_folder``    ``str``        Folder to write log file within ``/output``      ``None``
-        ``log_file``      ``str``        Log file name                                    ``log``
-        ================  =============  ===============================================  =====================
     """
     solver_id = 'PreSharpy'
+    solver_classification = 'loader'
+
+    settings_types = dict()
+    settings_default = dict()
+    settings_description = dict()
+
+    settings_types['flow'] = 'list(str)'
+    settings_default['flow'] = None
+    settings_description['flow'] = "List of the desired solvers' ``solver_id`` to run in sequential order."
+
+    settings_types['case'] = 'str'
+    settings_default['case'] = 'default_case_name'
+    settings_description['case'] = 'Case name'
+
+    settings_types['route'] = 'str'
+    settings_default['route'] = None
+    settings_description['route'] = 'Route to case files'
+
+    settings_types['write_screen'] = 'bool'
+    settings_default['write_screen'] = True
+    settings_description['write_screen'] = 'Display output on terminal screen.'
+
+    settings_types['write_log'] = 'bool'
+    settings_default['write_log'] = False
+    settings_description['write_log'] = 'Write log file'
+
+    settings_types['log_folder'] = 'str'
+    settings_default['log_folder'] = ''
+    settings_description['log_folder'] = 'Log folder destination directory'
+
+    settings_table = settings.SettingsTable()
+    __doc__ += settings_table.generate(settings_types, settings_default, settings_description,
+                                       'The following are the settings that the PreSharpy class takes:')
 
     def __init__(self, in_settings=None):
         self._settings = True
@@ -52,27 +72,6 @@ class PreSharpy(object):
             self._settings = False
 
         self.ts = 0
-
-        self.settings_types = dict()
-        self.settings_default = dict()
-
-        self.settings_types['flow'] = 'list(str)'
-        self.settings_default['flow'] = None
-
-        self.settings_types['case'] = 'str'
-        self.settings_default['case'] = 'default_case_name'
-
-        self.settings_types['route'] = 'str'
-        self.settings_default['route'] = None
-
-        self.settings_types['write_screen'] = 'bool'
-        self.settings_default['write_screen'] = True
-
-        self.settings_types['write_log'] = 'bool'
-        self.settings_default['write_log'] = False
-
-        self.settings_types['log_folder'] = 'str'
-        self.settings_default['log_folder'] = ''
 
         self.settings_types['log_file'] = 'str'
         self.settings_default['log_file'] = 'log'
@@ -111,15 +110,6 @@ class PreSharpy(object):
 
     @staticmethod
     def load_config_file(file_name):
-        """Reads the flight condition and solver input files.
-
-        Args:
-            file_name (str): contains the path and file name of the file to be read by the ``configparser``
-                reader.
-
-        Returns:
-            ``ConfigParser`` object that behaves like a dictionary
-        """
         config = configparser.ConfigParser()
         config.read(file_name)
         return config

--- a/sharpy/utils/docutils.py
+++ b/sharpy/utils/docutils.py
@@ -14,7 +14,6 @@ import yaml
 import sharpy.utils.sharpydir as sharpydir
 import sharpy.utils.exceptions as exceptions
 import sharpy.utils.solver_interface as solver_interface
-import sharpy.utils.generator_interface as generator_interface
 
 
 def generate_documentation():

--- a/sharpy/utils/settings.py
+++ b/sharpy/utils/settings.py
@@ -112,69 +112,75 @@ def to_custom_types(dictionary, types, default, no_ctype=False):
 
         elif v == 'list(float)':
             try:
-                if isinstance(dictionary[k], np.ndarray):
-                    continue
-                if isinstance(dictionary[k], list):
-                    for i in range(len(dictionary[k])):
-                        dictionary[k][i] = float(dictionary[k][i])
-                    dictionary[k] = np.array(dictionary[k])
-                    continue
-                # dictionary[k] = dictionary[k].split(',')
-                # # getting rid of leading and trailing spaces
-                # dictionary[k] = list(map(lambda x: x.strip(), dictionary[k]))
-                if dictionary[k].find(',') < 0:
-                    dictionary[k] = np.fromstring(dictionary[k].strip('[]'), sep=' ', dtype=ct.c_double)
-                else:
-                    dictionary[k] = np.fromstring(dictionary[k].strip('[]'), sep=',', dtype=ct.c_double)
+                dictionary[k]
             except KeyError:
                 if default[k] is None:
                     raise exceptions.NoDefaultValueException(k)
                 dictionary[k] = default[k].copy()
                 notify_default_value(k, dictionary[k])
+
+            if isinstance(dictionary[k], np.ndarray):
+                continue
+            if isinstance(dictionary[k], list):
+                for i in range(len(dictionary[k])):
+                    dictionary[k][i] = float(dictionary[k][i])
+                dictionary[k] = np.array(dictionary[k])
+                continue
+            # dictionary[k] = dictionary[k].split(',')
+            # # getting rid of leading and trailing spaces
+            # dictionary[k] = list(map(lambda x: x.strip(), dictionary[k]))
+            if dictionary[k].find(',') < 0:
+                dictionary[k] = np.fromstring(dictionary[k].strip('[]'), sep=' ', dtype=ct.c_double)
+            else:
+                dictionary[k] = np.fromstring(dictionary[k].strip('[]'), sep=',', dtype=ct.c_double)
 
         elif v == 'list(int)':
             try:
-                if isinstance(dictionary[k], np.ndarray):
-                    continue
-                if isinstance(dictionary[k], list):
-                    for i in range(len(dictionary[k])):
-                        dictionary[k][i] = int(dictionary[k][i])
-                    dictionary[k] = np.array(dictionary[k])
-                    continue
-                # dictionary[k] = dictionary[k].split(',')
-                # # getting rid of leading and trailing spaces
-                # dictionary[k] = list(map(lambda x: x.strip(), dictionary[k]))
-                if dictionary[k].find(',') < 0:
-                    dictionary[k] = np.fromstring(dictionary[k].strip('[]'), sep=' ').astype(ct.c_int)
-                else:
-                    dictionary[k] = np.fromstring(dictionary[k].strip('[]'), sep=',').astype(ct.c_int)
+                dictionary[k]
             except KeyError:
                 if default[k] is None:
                     raise exceptions.NoDefaultValueException(k)
                 dictionary[k] = default[k].copy()
                 notify_default_value(k, dictionary[k])
 
+            if isinstance(dictionary[k], np.ndarray):
+                continue
+            if isinstance(dictionary[k], list):
+                for i in range(len(dictionary[k])):
+                    dictionary[k][i] = int(dictionary[k][i])
+                dictionary[k] = np.array(dictionary[k])
+                continue
+            # dictionary[k] = dictionary[k].split(',')
+            # # getting rid of leading and trailing spaces
+            # dictionary[k] = list(map(lambda x: x.strip(), dictionary[k]))
+            if dictionary[k].find(',') < 0:
+                dictionary[k] = np.fromstring(dictionary[k].strip('[]'), sep=' ').astype(ct.c_int)
+            else:
+                dictionary[k] = np.fromstring(dictionary[k].strip('[]'), sep=',').astype(ct.c_int)
+
         elif v == 'list(complex)':
             try:
-                if isinstance(dictionary[k], np.ndarray):
-                    continue
-                if isinstance(dictionary[k], list):
-                    for i in range(len(dictionary[k])):
-                        dictionary[k][i] = float(dictionary[k][i])
-                    dictionary[k] = np.array(dictionary[k])
-                    continue
-                # dictionary[k] = dictionary[k].split(',')
-                # # getting rid of leading and trailing spaces
-                # dictionary[k] = list(map(lambda x: x.strip(), dictionary[k]))
-                if dictionary[k].find(',') < 0:
-                    dictionary[k] = np.fromstring(dictionary[k].strip('[]'), sep=' ').astype(complex)
-                else:
-                    dictionary[k] = np.fromstring(dictionary[k].strip('[]'), sep=',').astype(complex)
+                dictionary[k]
             except KeyError:
                 if default[k] is None:
                     raise exceptions.NoDefaultValueException(k)
                 dictionary[k] = default[k].copy()
                 notify_default_value(k, dictionary[k])
+
+            if isinstance(dictionary[k], np.ndarray):
+                continue
+            if isinstance(dictionary[k], list):
+                for i in range(len(dictionary[k])):
+                    dictionary[k][i] = float(dictionary[k][i])
+                dictionary[k] = np.array(dictionary[k])
+                continue
+            # dictionary[k] = dictionary[k].split(',')
+            # # getting rid of leading and trailing spaces
+            # dictionary[k] = list(map(lambda x: x.strip(), dictionary[k]))
+            if dictionary[k].find(',') < 0:
+                dictionary[k] = np.fromstring(dictionary[k].strip('[]'), sep=' ').astype(complex)
+            else:
+                dictionary[k] = np.fromstring(dictionary[k].strip('[]'), sep=',').astype(complex)
 
         elif v == 'dict':
             try:

--- a/sharpy/utils/solver_interface.py
+++ b/sharpy/utils/solver_interface.py
@@ -132,10 +132,6 @@ def output_documentation(route=None):
         solver = v()
         created_solvers[k] = solver
 
-        if solver.solver_id == 'PreSharpy':
-            continue
-            # route_to_solver_python = 'sharpy.presharpy.'
-
         filename = k + '.rst'
 
         try:
@@ -158,7 +154,8 @@ def output_documentation(route=None):
             if solver_folder not in solver_types:
                 solver_types.append(solver_folder)
 
-
+        if solver.solver_id == 'PreSharpy':
+            route_to_solver_python = 'sharpy.presharpy.'
 
         os.makedirs(base_route + '/' + folder + '/' + solver_folder, exist_ok=True)
         title = k + '\n'


### PR DESCRIPTION
Following on from the discussion in #32, default settings now get the value specified in their respective `settings_types` as opposed to having their own type.

For an unprovided setting with `settings_type['current_setting'] = list(float)` and `settings_default['current_setting'] = [1. , 0., 0.]`

Old behaviour would process setting as `list`. New behaviour will process it as `np.array` (as are all user-defined settings that are given the type `list(float)`).

Fixes #33 as well, no need for the revert.

All tests passed :+1: 

