### PR TITLE
Change position of --name argument in docs

### DIFF
--- a/docs/source/content/installation.md
+++ b/docs/source/content/installation.md
@@ -54,7 +54,7 @@ docker pull fonsocarre/sharpy:latest
 
 Now you can run it:
 ```
-docker run -it fonsocarre/sharpy:latest --name sharpy
+docker run --name sharpy -it fonsocarre/sharpy:latest
 ```
 You should see a welcome dialog such as:
 ```


### PR DESCRIPTION
As part of the review for https://github.com/openjournals/joss-reviews/issues/1885.

I am running the docker image in Windows, and needed to change the order of this argument to avoid getting an error from bash: `/bin/bash: --name: invalid option`.