### PR TITLE
New settings check against valid options

### DIFF
--- a/docs/source/includes/utils/settings/check_settings.rst
+++ b/docs/source/includes/utils/settings/check_settings.rst
@@ -1,0 +1,4 @@
+check_settings
+--------------
+
+.. automodule:: sharpy.utils.settings.check_settings

--- a/docs/source/includes/utils/settings/index.rst
+++ b/docs/source/includes/utils/settings/index.rst
@@ -8,4 +8,5 @@ Settings Generator Utilities
 	:glob:
 
 	./SettingsTable
+	./check_settings
 	./load_config_file

--- a/sharpy/generators/gustvelocityfield.py
+++ b/sharpy/generators/gustvelocityfield.py
@@ -89,7 +89,8 @@ class one_minus_cos(BaseGust):
     settings_description['gust_intensity'] = 'Intensity of the gust :math:`u_{de}`.'
 
     setting_table = settings.SettingsTable()
-    __doc__ += setting_table.generate(settings_types, settings_default, settings_description, doc_settings_description)
+    __doc__ += setting_table.generate(settings_types, settings_default, settings_description,
+                                      header_line=doc_settings_description)
 
     def initialise(self, in_dict):
         self.settings = in_dict
@@ -135,7 +136,8 @@ class DARPA(BaseGust):
     settings_description['span'] = 'Wing span'
 
     setting_table = settings.SettingsTable()
-    __doc__ += setting_table.generate(settings_types, settings_default, settings_description, doc_settings_description)
+    __doc__ += setting_table.generate(settings_types, settings_default, settings_description,
+                                      header_line=doc_settings_description)
 
     def initialise(self, in_dict):
         self.settings = in_dict
@@ -179,7 +181,8 @@ class continuous_sin(BaseGust):
     settings_description['gust_intensity'] = 'Intensity of the gust'
 
     setting_table = settings.SettingsTable()
-    __doc__ += setting_table.generate(settings_types, settings_default, settings_description, doc_settings_description)
+    __doc__ += setting_table.generate(settings_types, settings_default, settings_description,
+                                      header_line=doc_settings_description)
 
     def initialise(self, in_dict):
         self.settings = in_dict
@@ -217,7 +220,8 @@ class lateral_one_minus_cos(BaseGust):
     settings_description['gust_intensity'] = 'Intensity of the gust'
 
     setting_table = settings.SettingsTable()
-    __doc__ += setting_table.generate(settings_types, settings_default, settings_description, doc_settings_description)
+    __doc__ += setting_table.generate(settings_types, settings_default, settings_description,
+                                      header_line=doc_settings_description)
 
     def initialise(self, in_dict):
         self.settings = in_dict
@@ -255,7 +259,8 @@ class time_varying(BaseGust):
     settings_description['file'] = 'File with the information'
 
     setting_table = settings.SettingsTable()
-    __doc__ += setting_table.generate(settings_types, settings_default, settings_description, doc_settings_description)
+    __doc__ += setting_table.generate(settings_types, settings_default, settings_description,
+                                      header_line=doc_settings_description)
 
     def __init__(self):
         super().__init__()
@@ -299,7 +304,8 @@ class time_varying_global(BaseGust):
     settings_description['file'] = 'File with the information (only for time varying)'
 
     setting_table = settings.SettingsTable()
-    __doc__ += setting_table.generate(settings_types, settings_default, settings_description, doc_settings_description)
+    __doc__ += setting_table.generate(settings_types, settings_default, settings_description,
+                                      header_line=doc_settings_description)
 
     def __init__(self):
         super().__init__()
@@ -357,7 +363,8 @@ class span_sine(BaseGust):
     settings_description['span_with_gust'] = 'Extension of the span to which the gust will be applied'
 
     setting_table = settings.SettingsTable()
-    __doc__ += setting_table.generate(settings_types, settings_default, settings_description, doc_settings_description)
+    __doc__ += setting_table.generate(settings_types, settings_default, settings_description,
+                                      header_line=doc_settings_description)
 
     def initialise(self, in_dict):
         self.settings = in_dict
@@ -428,8 +435,8 @@ class GustVelocityField(generator_interface.BaseGenerator):
     settings_description['gust_parameters'] = 'Dictionary of parameters specific of the gust_shape selected'
 
     setting_table = settings.SettingsTable()
-    __doc__ += setting_table.generate(settings_types, settings_default, settings_description, 'This generator takes'
-                                                                                              'the following settings')
+    __doc__ += setting_table.generate(settings_types, settings_default, settings_description,
+                                      header_line='This generator takes the following settings')
 
     def __init__(self):
 

--- a/sharpy/linear/assembler/linearbeam.py
+++ b/sharpy/linear/assembler/linearbeam.py
@@ -63,6 +63,7 @@ class LinearBeam(BaseElement):
     settings_types = dict()
     settings_default = dict()
     settings_description = dict()
+    settings_options = dict()
 
     settings_default['modal_projection'] = True
     settings_types['modal_projection'] = 'bool'
@@ -71,6 +72,7 @@ class LinearBeam(BaseElement):
     settings_default['inout_coords'] = 'nodes'
     settings_types['inout_coords'] = 'str'
     settings_description['inout_coords'] = 'Beam state space input/output coordinates. ``modes`` or ``nodes``'
+    settings_options['inout_coords'] = ['nodes', 'modes']
 
     settings_types['num_modes'] = 'int'
     settings_default['num_modes'] = 10
@@ -138,7 +140,8 @@ class LinearBeam(BaseElement):
                 self.settings = data.settings['LinearAssembler']['linear_system_settings']
             except KeyError:
                 pass
-        settings.to_custom_types(self.settings, self.settings_types, self.settings_default, no_ctype=True)
+        settings.to_custom_types(self.settings, self.settings_types, self.settings_default,
+                                 self.settings_options, no_ctype=True)
 
         beam = lingebm.FlexDynamic(data.linear.tsstruct0, data.structure, self.settings)
         self.sys = beam

--- a/sharpy/linear/assembler/linearbeam.py
+++ b/sharpy/linear/assembler/linearbeam.py
@@ -16,13 +16,11 @@ class LinearBeam(BaseElement):
     State space member
 
     Define class for linear state-space realisation of GEBM flexible-body
-    equations from SHARPy``timestep_info`` class and with the nonlinear structural information.
+    equations from SHARPy ``timestep_info`` class and with the nonlinear structural information.
 
     State-space models can be defined in continuous or discrete time (dt
     required). Modal projection, either on the damped or undamped modal shapes,
     is also avaiable.
-
-    To produce the state-space equations:
 
     Notes on the settings:
 
@@ -30,7 +28,7 @@ class LinearBeam(BaseElement):
             onto modal coordinates. Projection over damped or undamped modal
             shapes can be obtained selecting:
 
-                - ``proj_modes={'damped','undamped'}``
+                - ``proj_modes = {'damped','undamped'}``
 
             while
 
@@ -57,6 +55,8 @@ class LinearBeam(BaseElement):
             over the undamped structural modes (``modal_projection=True`` and ``proj_modes``).
             The Zero-order holder and bilinear methods, instead, work in all
             descriptions, but require the continuous state-space equations.
+
+
     """
     sys_id = "LinearBeam"
 
@@ -71,7 +71,7 @@ class LinearBeam(BaseElement):
 
     settings_default['inout_coords'] = 'nodes'
     settings_types['inout_coords'] = 'str'
-    settings_description['inout_coords'] = 'Beam state space input/output coordinates. ``modes`` or ``nodes``'
+    settings_description['inout_coords'] = 'Beam state space input/output coordinates'
     settings_options['inout_coords'] = ['nodes', 'modes']
 
     settings_types['num_modes'] = 'int'
@@ -89,10 +89,12 @@ class LinearBeam(BaseElement):
     settings_default['proj_modes'] = 'undamped'
     settings_types['proj_modes'] = 'str'
     settings_description['proj_modes'] = 'Use ``undamped`` or ``damped`` modes'
+    settings_options['proj_modes'] = ['damped', 'undamped']
 
     settings_default['discr_method'] = 'newmark'
     settings_types['discr_method'] = 'str'
-    settings_description['discr_method'] = 'Discrete time assembly system method: ``newmark`` or ``zoh``'
+    settings_description['discr_method'] = 'Discrete time assembly system method:'
+    settings_options['discr_method'] = ['newmark', 'zoh', 'bilinear']
 
     settings_default['newmark_damp'] = 1e-4
     settings_types['newmark_damp'] = 'float'
@@ -112,14 +114,15 @@ class LinearBeam(BaseElement):
 
     settings_types['remove_dofs'] = 'list(str)'
     settings_default['remove_dofs'] = []
-    settings_description['remove_dofs'] = 'Remove desired degrees of freedom: ``eta``, ``V``, ``W`` or ``orient``'
+    settings_description['remove_dofs'] = 'Remove desired degrees of freedom'
+    settings_options['remove_dofs'] = ['eta', 'V', 'W', 'orient']
 
     settings_types['remove_sym_modes'] = 'bool'
     settings_default['remove_sym_modes'] = False
     settings_description['remove_sym_modes'] = 'Remove symmetric modes if wing is clamped'
 
     settings_table = settings.SettingsTable()
-    __doc__ += settings_table.generate(settings_types, settings_default, settings_description)
+    __doc__ += settings_table.generate(settings_types, settings_default, settings_description, settings_options)
 
     def __init__(self):
         self.sys = None  # The actual object
@@ -498,3 +501,6 @@ class VectorVariable(object):
     @property
     def size(self):
         return self.end_pos - self.first_pos
+
+if __name__=='__main__':
+    print(LinearBeam.__doc__)

--- a/sharpy/linear/assembler/linearuvlm.py
+++ b/sharpy/linear/assembler/linearuvlm.py
@@ -77,6 +77,7 @@ class LinearUVLM(ss_interface.BaseElement):
     settings_types = dict()
     settings_default = dict()
     settings_description = dict()
+    settings_options = dict()
 
     settings_types['dt'] = 'float'
     settings_default['dt'] = 0.1
@@ -85,6 +86,7 @@ class LinearUVLM(ss_interface.BaseElement):
     settings_types['integr_order'] = 'int'
     settings_default['integr_order'] = 2
     settings_description['integr_order'] = 'Integration order of the circulation derivative. Either ``1`` or ``2``.'
+    settings_options['integr_order'] = [1, 2]
 
     settings_types['ScalingDict'] = 'dict'
     settings_default['ScalingDict'] = dict()
@@ -105,10 +107,12 @@ class LinearUVLM(ss_interface.BaseElement):
     settings_types['remove_inputs'] = 'list(str)'
     settings_default['remove_inputs'] = []
     settings_description['remove_inputs'] = 'List of inputs to remove. ``u_gust`` to remove external velocity input.'
+    settings_options['remove_inputs'] = ['u_gust']
 
     settings_types['gust_assembler'] = 'str'
     settings_default['gust_assembler'] = ''
     settings_description['gust_assembler'] = 'Selected gust assembler. ``leading_edge`` for now'
+    settings_options['gust_assembler'] = ['leading_edge']
 
     settings_types['rom_method'] = 'list(str)'
     settings_default['rom_method'] = []
@@ -120,7 +124,7 @@ class LinearUVLM(ss_interface.BaseElement):
                                                   'where the name is the key to the dictionary'
 
     settings_table = settings.SettingsTable()
-    __doc__ += settings_table.generate(settings_types, settings_default, settings_description)
+    __doc__ += settings_table.generate(settings_types, settings_default, settings_description, settings_options)
 
     scaling_settings_types = dict()
     scaling_settings_default = dict()
@@ -172,7 +176,9 @@ class LinearUVLM(ss_interface.BaseElement):
             except KeyError:
                 pass
 
-        settings.to_custom_types(self.settings, self.settings_types, self.settings_default, no_ctype=True)
+        settings.to_custom_types(self.settings, self.settings_types, self.settings_default,
+                                 self.settings_options,
+                                 no_ctype=True)
         settings.to_custom_types(self.settings['ScalingDict'], self.scaling_settings_types,
                                  self.scaling_settings_default, no_ctype=True)
 

--- a/sharpy/presharpy/presharpy.py
+++ b/sharpy/presharpy/presharpy.py
@@ -63,7 +63,7 @@ class PreSharpy(object):
 
     settings_table = settings.SettingsTable()
     __doc__ += settings_table.generate(settings_types, settings_default, settings_description,
-                                       'The following are the settings that the PreSharpy class takes:')
+                                       header_line='The following are the settings that the PreSharpy class takes:')
 
     def __init__(self, in_settings=None):
         self._settings = True
@@ -113,4 +113,3 @@ class PreSharpy(object):
         config = configparser.ConfigParser()
         config.read(file_name)
         return config
-

--- a/sharpy/rom/balanced.py
+++ b/sharpy/rom/balanced.py
@@ -35,6 +35,7 @@ class Direct(BaseBalancedRom):
     settings_types = dict()
     settings_default = dict()
     settings_description = dict()
+    settings_options = dict()
 
     settings_types['tune'] = 'bool'
     settings_default['tune'] = True
@@ -56,10 +57,11 @@ class Direct(BaseBalancedRom):
 
     settings_types['reduction_method'] = 'str'
     settings_default['reduction_method'] = 'realisation'
-    settings_description['reduction_method'] = 'Reduction method. ``realisation`` or ``truncation``'
+    settings_description['reduction_method'] = 'Desired reduction method'
+    settings_options['reduction_method'] = ['realisation', 'truncation']
 
     settings_table = settings.SettingsTable()
-    __doc__ += settings_table.generate(settings_types, settings_default, settings_description)
+    __doc__ += settings_table.generate(settings_types, settings_default, settings_description, settings_options)
 
     def __init__(self):
         self.settings = dict()
@@ -68,7 +70,7 @@ class Direct(BaseBalancedRom):
         if in_settings is not None:
             self.settings = in_settings
 
-        settings.to_custom_types(self.settings, self.settings_types, self.settings_default)
+        settings.to_custom_types(self.settings, self.settings_types, self.settings_default, self.settings_options)
 
     def run(self, ss):
         A, B, C, D = ss.get_mats()
@@ -116,6 +118,7 @@ class FrequencyLimited(BaseBalancedRom):
     settings_types = dict()
     settings_default = dict()
     settings_description = dict()
+    settings_options = dict()
 
     settings_types['frequency'] = 'float'
     settings_default['frequency'] = 1.
@@ -126,8 +129,9 @@ class FrequencyLimited(BaseBalancedRom):
 
     settings_types['method_low'] = 'str'
     settings_default['method_low'] = 'trapz'
-    settings_description['method_low'] = '``gauss`` or ``trapz`` specifies whether to use gauss quadrature or ' \
+    settings_description['method_low'] = 'Specifies whether to use gauss quadrature or ' \
                                          'trapezoidal rule in the low-frequency range ``[0,F]``'
+    settings_options['method_low'] = ['gauss', 'trapz']
 
     settings_types['options_low'] = 'dict'
     settings_default['options_low'] = dict()
@@ -135,8 +139,9 @@ class FrequencyLimited(BaseBalancedRom):
 
     settings_types['method_high'] = 'str'
     settings_default['method_high'] = 'trapz'
-    settings_description['method_high'] = '``gauss`` or ``trapz`` specifies whether to use gauss quadrature or ' \
-                                         'trapezoidal rule in the high-frequency range ``[F,FN]``'
+    settings_description['method_high'] = 'Specifies whether to use gauss quadrature or ' \
+                                          'trapezoidal rule in the high-frequency range ``[F,FN]``'
+    settings_options['method_high'] = ['gauss', 'trapz']
 
     settings_types['options_high'] = 'dict'
     settings_default['options_high'] = dict()
@@ -174,7 +179,7 @@ class FrequencyLimited(BaseBalancedRom):
     settings_options_description['order'] = 'Order of Gauss-Lobotto quadratures'
 
     settings_table = settings.SettingsTable()
-    __doc__ += settings_table.generate(settings_types, settings_default, settings_description)
+    __doc__ += settings_table.generate(settings_types, settings_default, settings_description, settings_options)
 
     options_table = settings.SettingsTable()
     __doc__ += options_table.generate(settings_options_types, settings_options_default, settings_options_description,
@@ -188,9 +193,12 @@ class FrequencyLimited(BaseBalancedRom):
         if in_settings is not None:
             self.settings = in_settings
 
-        settings.to_custom_types(self.settings, self.settings_types, self.settings_default, no_ctype=True)
-        settings.to_custom_types(self.settings['options_low'], self.settings_options_types, self.settings_options_default, no_ctype=True)
-        settings.to_custom_types(self.settings['options_high'], self.settings_options_types, self.settings_options_default, no_ctype=True)
+        settings.to_custom_types(self.settings, self.settings_types, self.settings_default,
+                                 self.settings_options, no_ctype=True)
+        settings.to_custom_types(self.settings['options_low'], self.settings_options_types,
+                                 self.settings_options_default, no_ctype=True)
+        settings.to_custom_types(self.settings['options_high'], self.settings_options_types,
+                                 self.settings_options_default, no_ctype=True)
 
     def run(self, ss):
 

--- a/sharpy/rom/balanced.py
+++ b/sharpy/rom/balanced.py
@@ -178,7 +178,7 @@ class FrequencyLimited(BaseBalancedRom):
 
     options_table = settings.SettingsTable()
     __doc__ += options_table.generate(settings_options_types, settings_options_default, settings_options_description,
-                                      'The parameters of integration take the following options:\n')
+                                      header_line='The parameters of integration take the following options:\n')
 
     def __init__(self):
         self.settings = dict()

--- a/sharpy/solvers/stepuvlm.py
+++ b/sharpy/solvers/stepuvlm.py
@@ -36,6 +36,7 @@ class StepUvlm(BaseSolver):
     settings_types = dict()
     settings_default = dict()
     settings_description = dict()
+    settings_options = dict()
 
     settings_types['print_info'] = 'bool'
     settings_default['print_info'] = True
@@ -51,12 +52,16 @@ class StepUvlm(BaseSolver):
 
     settings_types['convection_scheme'] = 'int'
     settings_default['convection_scheme'] = 3
-    settings_description['convection_scheme'] = '0 for fixed wake, 2 for convected with background flow and 3 for full force-free wake'
+    settings_description['convection_scheme'] = '``0``: fixed wake, ' \
+                                                '``2``: convected with background flow;' \
+                                                '``3``: full force-free wake'
+    settings_options['convection_scheme'] = [0, 2, 3]
 
     settings_types['dt'] = 'float'
     settings_default['dt'] = 0.1
     settings_description['dt'] = 'Time step'
 
+    # the following settings are not in used but are required in place since they are called in uvlmlib
     settings_types['iterative_solver'] = 'bool'
     settings_default['iterative_solver'] = False
     settings_description['iterative_solver'] = 'Not in use'
@@ -71,7 +76,8 @@ class StepUvlm(BaseSolver):
 
     settings_types['velocity_field_generator'] = 'str'
     settings_default['velocity_field_generator'] = 'SteadyVelocityField'
-    settings_description['velocity_field_generator'] = 'Name of the velocity field generator to be used in the simulation'
+    settings_description['velocity_field_generator'] = 'Name of the velocity field generator to be used in the ' \
+                                                       'simulation'
 
     settings_types['velocity_field_input'] = 'dict'
     settings_default['velocity_field_input'] = {}
@@ -79,14 +85,15 @@ class StepUvlm(BaseSolver):
 
     settings_types['gamma_dot_filtering'] = 'int'
     settings_default['gamma_dot_filtering'] = 0
-    settings_description['gamma_dot_filtering'] = 'Filtering parameter for the Welch filter for the Gamma_dot estimation. Used when ``unsteady_force_contribution`` is ``on``.'
+    settings_description['gamma_dot_filtering'] = 'Filtering parameter for the Welch filter for the Gamma_dot ' \
+                                                  'estimation. Used when ``unsteady_force_contribution`` is ``on``.'
 
     settings_types['rho'] = 'float'
     settings_default['rho'] = 1.225
     settings_description['rho'] = 'Air density'
 
     settings_table = settings.SettingsTable()
-    __doc__ += settings_table.generate(settings_types, settings_default, settings_description)
+    __doc__ += settings_table.generate(settings_types, settings_default, settings_description, settings_options)
 
     def __init__(self):
         self.data = None
@@ -104,7 +111,8 @@ class StepUvlm(BaseSolver):
             self.settings = custom_settings
         settings.to_custom_types(self.settings,
                                  self.settings_types,
-                                 self.settings_default)
+                                 self.settings_default,
+                                 self.settings_options)
 
         self.data.structure.add_unsteady_information(
             self.data.structure.dyn_dict,

--- a/sharpy/utils/exceptions.py
+++ b/sharpy/utils/exceptions.py
@@ -57,3 +57,18 @@ class NotConvergedSolver(Exception):
     """
     pass
 
+
+class NotValidSetting(DefaultValueBaseException):
+    """
+    Raised when a user gives a setting an invalid value
+    """
+
+    def __init__(self, setting, variable, options, value=None, message=''):
+        message = 'The setting %s with entry %s is not one of the valid options: %s' % (setting, variable, options)
+        super().__init__(variable, value, message=message)
+        if cout.cout_wrap is None:
+            print(message)
+        else:
+            cout.cout_wrap.print_separator(3)
+            cout.cout_wrap(message, 3)
+            cout.cout_wrap.print_separator(3)

--- a/sharpy/utils/settings.py
+++ b/sharpy/utils/settings.py
@@ -196,7 +196,8 @@ def to_custom_types(dictionary, types, default, options=dict(), no_ctype=False):
 
         # Check that value is within options
         try:
-            if dictionary[k] not in options[k]:
+            if dictionary[k] not in options[k] and dictionary[k]:
+                # checks that the value is within the options and that it is not an empty string.
                 raise ValueError('The setting %s is not one of the available options: %s' % (k, options[k]))
         except KeyError:
             pass
@@ -284,6 +285,7 @@ class SettingsTable:
         self.settings_description = dict()
         self.settings_default = dict()
         self.settings_options = dict()
+        self.settings_options_strings = dict()
 
         self.line_format = ''
 
@@ -346,12 +348,12 @@ class SettingsTable:
         return table_string
 
     def process_options(self):
-
+        self.settings_options_strings = self.settings_options.copy()
         for k, v in self.settings_options.items():
             opts = ''
             for option in v:
                 opts += ' ``%s``,' %str(option)
-            self.settings_options[k] = opts[1:-1]  # removes the initial whitespace and final comma
+            self.settings_options_strings[k] = opts[1:-1]  # removes the initial whitespace and final comma
 
     def set_field_length(self):
 
@@ -360,7 +362,7 @@ class SettingsTable:
             stype = str(self.settings_types.get(setting, ''))
             description = self.settings_description.get(setting, '')
             default = str(self.settings_default.get(setting, ''))
-            option = str(self.settings_options.get(setting, ''))
+            option = str(self.settings_options_strings.get(setting, ''))
 
             field_lengths[0].append(len(setting) + 4)  # length of name
             field_lengths[1].append(len(stype) + 4)  # length of type + 4 for the rst ``X``
@@ -386,7 +388,7 @@ class SettingsTable:
         description = self.settings_description.get(setting, '')
         default = '``' + str(self.settings_default.get(setting, '')) + '``'
         if self.settings_options:
-            option = self.settings_options.get(setting, '')
+            option = self.settings_options_strings.get(setting, '')
             line = self.line_format.format(['``' + str(setting) + '``', type, description, default, option]) + '\n'
         else:
             line = self.line_format.format(['``' + str(setting) + '``', type, description, default]) + '\n'

--- a/sharpy/utils/settings.py
+++ b/sharpy/utils/settings.py
@@ -194,13 +194,46 @@ def to_custom_types(dictionary, types, default, options=dict(), no_ctype=False):
         else:
             raise TypeError('Variable %s has an unknown type (%s) that cannot be casted' % (k, v))
 
-        # Check that value is within options
-        try:
-            if dictionary[k] not in options[k] and dictionary[k]:
+    check_settings(dictionary, types, options)
+
+
+def check_settings(settings, settings_types, settings_options):
+    """
+    Checks that settings given a type ``str`` or ``int`` and allowable options are indeed valid.
+
+    Args:
+        settings (dict): Dictionary of processed settings
+        settings_types (dict): Dictionary of settings types
+        settings_options (dict): Dictionary of options (may be empty)
+
+    Raises:
+        ValueError: if the setting is not allowed.
+    """
+    for k in settings_options:
+        if settings_types[k] == 'int':
+            try:
+                value = settings[k].value
+            except AttributeError:
+                value = settings[k]
+            if value not in settings_options[k]:
+                raise ValueError('The setting %s with value %s is not one of the available '
+                                 'options: %s' % (k, value, settings_options[k]))
+
+        elif settings_types[k] == 'str':
+            value = settings[k]
+            if value not in settings_options[k] and value:
                 # checks that the value is within the options and that it is not an empty string.
-                raise ValueError('The setting %s is not one of the available options: %s' % (k, options[k]))
-        except KeyError:
-            pass
+                raise ValueError('The setting %s with value %s is not one of the available '
+                                 'options: %s' % (k, value, settings_options[k]))
+
+        elif settings_types[k] == 'list(str)':
+            for item in settings[k]:
+                if item not in settings_options[k] and item:
+                    raise ValueError('The setting %s with item %s is not one of the available '
+                                     'options: %s' % (k, item, settings_options[k]))
+
+        else:
+            pass  # no other checks implemented / required
 
 
 def load_config_file(file_name: str) -> dict:

--- a/sharpy/utils/settings.py
+++ b/sharpy/utils/settings.py
@@ -207,7 +207,7 @@ def check_settings(settings, settings_types, settings_options):
         settings_options (dict): Dictionary of options (may be empty)
 
     Raises:
-        ValueError: if the setting is not allowed.
+        exception.NotValidSetting: if the setting is not allowed.
     """
     for k in settings_options:
         if settings_types[k] == 'int':
@@ -216,21 +216,18 @@ def check_settings(settings, settings_types, settings_options):
             except AttributeError:
                 value = settings[k]
             if value not in settings_options[k]:
-                raise ValueError('The setting %s with value %s is not one of the available '
-                                 'options: %s' % (k, value, settings_options[k]))
+                raise exceptions.NotValidSetting(k, value, settings_options[k])
 
         elif settings_types[k] == 'str':
             value = settings[k]
             if value not in settings_options[k] and value:
                 # checks that the value is within the options and that it is not an empty string.
-                raise ValueError('The setting %s with value %s is not one of the available '
-                                 'options: %s' % (k, value, settings_options[k]))
+                raise exceptions.NotValidSetting(k, value, settings_options[k])
 
         elif settings_types[k] == 'list(str)':
             for item in settings[k]:
                 if item not in settings_options[k] and item:
-                    raise ValueError('The setting %s with item %s is not one of the available '
-                                     'options: %s' % (k, item, settings_options[k]))
+                    raise exceptions.NotValidSetting(k, item, settings_options[k])
 
         else:
             pass  # no other checks implemented / required

--- a/sharpy/utils/settings.py
+++ b/sharpy/utils/settings.py
@@ -283,12 +283,13 @@ class SettingsTable:
         self.settings_types = dict()
         self.settings_description = dict()
         self.settings_default = dict()
+        self.settings_options = dict()
 
         self.line_format = ''
 
         self.table_string = ''
 
-    def generate(self, settings_types, settings_default, settings_description, header_line=None):
+    def generate(self, settings_types, settings_default, settings_description, settings_options=dict(), header_line=None):
         """
         Returns a rst-format table with the settings' names, types, description and default values
 
@@ -296,6 +297,7 @@ class SettingsTable:
             settings_types (dict): Setting types.
             settings_default (dict): Settings default value.
             settings_description (dict): Setting description.
+
             header_line (str): Header line description (optional)
 
         Returns:
@@ -305,6 +307,24 @@ class SettingsTable:
         self.settings_default = settings_default
         self.n_settings = len(self.settings_types)
         #
+
+        if header_line is None:
+            header_line = 'The settings that this solver accepts are given by a dictionary, ' \
+                          'with the following key-value pairs:'
+        else:
+            assert type(header_line) == str, 'header_line not a string, verify order of arguments'
+
+        if type(settings_options) != dict:
+            raise TypeError('settings_options is not a dictionary')
+
+        if settings_options:
+            # if settings_options are provided
+            self.settings_options = settings_options
+            self.n_fields += 1
+            self.field_length.append(0)
+            self.titles.append('Options')
+            self.process_options()
+
         try:
             self.settings_description = settings_description
         except AttributeError:
@@ -312,10 +332,6 @@ class SettingsTable:
 
         self.set_field_length()
         self.line_format = self.setting_line_format()
-
-        if header_line is None:
-            header_line = 'The settings that this solver accepts are given by a dictionary, ' \
-                          'with the following key-value pairs:'
 
         table_string = '\n    ' + header_line + '\n'
         table_string += '\n    ' + self.print_divider_line()
@@ -329,17 +345,30 @@ class SettingsTable:
 
         return table_string
 
+    def process_options(self):
+
+        for k, v in self.settings_options.items():
+            opts = ''
+            for option in v:
+                opts += ' ``%s``,' %str(option)
+            self.settings_options[k] = opts[1:-1]  # removes the initial whitespace and final comma
+
     def set_field_length(self):
 
-        field_lengths = [[], [], [], []]
+        field_lengths = [[] for i in range(self.n_fields)]
         for setting in self.settings_types:
             stype = str(self.settings_types.get(setting, ''))
             description = self.settings_description.get(setting, '')
             default = str(self.settings_default.get(setting, ''))
+            option = str(self.settings_options.get(setting, ''))
+
             field_lengths[0].append(len(setting) + 4)  # length of name
             field_lengths[1].append(len(stype) + 4)  # length of type + 4 for the rst ``X``
-            field_lengths[2].append(len(description))  # length of type + 4 for the rst ``X``
+            field_lengths[2].append(len(description))  # length of type
             field_lengths[3].append(len(default) + 4)  # length of type + 4 for the rst ``X``
+
+            if self.settings_options:
+                field_lengths[4].append(len(option))
 
         for i_field in range(self.n_fields):
             field_lengths[i_field].append(len(self.titles[i_field]))
@@ -356,7 +385,11 @@ class SettingsTable:
         type = '``' + str(self.settings_types.get(setting, '')) + '``'
         description = self.settings_description.get(setting, '')
         default = '``' + str(self.settings_default.get(setting, '')) + '``'
-        line = self.line_format.format(['``' + str(setting) + '``', type, description, default]) + '\n'
+        if self.settings_options:
+            option = self.settings_options.get(setting, '')
+            line = self.line_format.format(['``' + str(setting) + '``', type, description, default, option]) + '\n'
+        else:
+            line = self.line_format.format(['``' + str(setting) + '``', type, description, default]) + '\n'
         return line
 
     def print_header(self):

--- a/sharpy/utils/settings.py
+++ b/sharpy/utils/settings.py
@@ -33,7 +33,7 @@ def cast(k, v, pytype, ctype, default):
     return val
 
 
-def to_custom_types(dictionary, types, default, no_ctype=False):
+def to_custom_types(dictionary, types, default, options=dict(), no_ctype=False):
     for k, v in types.items():
         if v == 'int':
             if no_ctype:
@@ -194,6 +194,12 @@ def to_custom_types(dictionary, types, default, no_ctype=False):
         else:
             raise TypeError('Variable %s has an unknown type (%s) that cannot be casted' % (k, v))
 
+        # Check that value is within options
+        try:
+            if dictionary[k] not in options[k]:
+                raise ValueError('The setting %s is not one of the available options: %s' % (k, options[k]))
+        except KeyError:
+            pass
 
 
 def load_config_file(file_name: str) -> dict:


### PR DESCRIPTION
Introduces a small new feature to check that settings are valid and also adds valid options to the relevant settings' documentation.

The same way we have `settings_types`, `settings_default` etc, we now have the dictionary `settings_options` for those settings that are either `int`, `str` or `list(str)` that have certain possible options. The entry for each setting in `settings_options` is a `list`.

Example: 
The convection scheme in `StepUvlm` is an `int` that can be `0`, `2` or `3`. The new dictionary would have an entry like:
```settings_options['convection_scheme'] = [0, 2, 3]```

To implement this feature to your code:
* Documentation table: 
```   __doc__ += settings_table.generate(settings_types, settings_default, settings_description, settings_options)```
* Settings to custom settings:
    ```        
    settings.to_custom_types(self.settings,
                                 self.settings_types,
                                 self.settings_default,
                                 self.settings_options)
    ```

This will check the settings and raise an error if the desired option is not valid. In the case of a string, it will always accept the empty string as valid without need of adding an empty string to the list of valid options.

This is totally backwards compatible and does not need any modification unless you would like to implement these settings check.

