### PR TITLE
Fix typo in unittests using tearDowns instead of tearDown

### DIFF
--- a/tests/coupled/multibody/double_pendulum/test_double_pendulum_geradin.py
+++ b/tests/coupled/multibody/double_pendulum/test_double_pendulum_geradin.py
@@ -313,7 +313,7 @@ class TestDoublePendulum(unittest.TestCase):
         self.assertAlmostEqual(pos_tip_data[-1, 2], 0.000000, 4)
         self.assertAlmostEqual(pos_tip_data[-1, 3], -0.9986984, 4)
 
-    def tearDowns(self):
+    def tearDown(self):
         solver_path = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
         solver_path += '/'
         files_to_delete = [name + '.aero.h5',

--- a/tests/coupled/multibody/fix_node_velocity_wrtA/test_fix_node_velocity_wrtA.py
+++ b/tests/coupled/multibody/fix_node_velocity_wrtA/test_fix_node_velocity_wrtA.py
@@ -180,7 +180,7 @@ class TestFixNodeVelocitywrtA(unittest.TestCase):
         self.assertAlmostEqual(pos_root_data[-1, 2], 0.0, 2)
         self.assertAlmostEqual(pos_root_data[-1, 3], 0.0, 2)
 
-    def tearDowns(self):
+    def tearDown(self):
         # pass
         files_to_delete = [name + '.aero.h5',
                            name + '.dyn.h5',

--- a/tests/coupled/prescribed/gamma_dot_test/test_gamma_dot.py
+++ b/tests/coupled/prescribed/gamma_dot_test/test_gamma_dot.py
@@ -179,7 +179,7 @@ class TestGammaDot(unittest.TestCase):
 
                     self.run_test(aero_type, predictor, sparse, integration_order)
 
-    def tearDowns(self):
+    def tearDown(self):
 
         solver_path = os.path.dirname(os.path.realpath(__file__))
         # solver_path += '/'

--- a/tests/xbeam/test_xbeam.py
+++ b/tests/xbeam/test_xbeam.py
@@ -38,7 +38,7 @@ class TestGeradinXbeam(unittest.TestCase):
         psi_data = np.atleast_2d(np.genfromtxt(output_path + 'struct_psi_node-1.dat'))
         self.assertAlmostEqual(psi_data[-1, 2], 0.6720, 3)
 
-    def tearDowns(self):
+    def tearDown(self):
         solver_path = os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + '/geradin/')
         files_to_delete = list()
         extensions = ('*.txt', '*.h5')


### PR DESCRIPTION
Some unittests were incorrectly calling `tearDowns()` instead of `tearDown()`. This pull request fixes this.