### PR TITLE
JOSS Paper Minor typos fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,6 @@ RUN conda init bash && \
 RUN ln -s /sharpy_dir/utils/docker/* /root/
 
 RUN cd sharpy_dir && \
-    git submodule init && \
-    git submodule update && \
     conda activate sharpy_minimal && \
     mkdir build && \
     cd build && \

--- a/docs/JOSS/paper.bib
+++ b/docs/JOSS/paper.bib
@@ -223,7 +223,7 @@ journal = {AIAA Journal},
 month = {mar},
 number = {3},
 pages = {528--538},
-title = {{Consistent Structural Linearization in Flexible Aircraft Dynamics with Large Rigid-Body Motion}},
+title = {Consistent Structural Linearization in Flexible Aircraft Dynamics with Large Rigid-Body Motion},
 volume = {52},
 year = {2014}
 }
@@ -348,7 +348,7 @@ year = {2012}
  @inproceedings{del2019efficient,
   title={Low-Altitude Dynamics of Very Flexible Aircraft},
   author={Del Carre, Alfonso and Palacios, Rafael},
-  booktitle={AIAA Scitech 2019 Forum},
+  booktitle={AIAA SciTech 2019 Forum},
   address={San Diego, California},
   year={2019},
   publisher = {American Institute of Aeronautics and Astronautics},

--- a/docs/JOSS/paper.bib
+++ b/docs/JOSS/paper.bib
@@ -65,7 +65,7 @@
   publisher = {American Institute of Aeronautics and Astronautics},
   author = {Mark Drela},
   title = {Integrated simulation model for preliminary aerodynamic,  structural,  and control-law design of aircraft},
-  booktitle = {40th Structures,  Structural Dynamics,  and Materials Conference and Exhibit}
+  booktitle = {{40th Structures,  Structural Dynamics,  and Materials Conference and Exhibit}}
 }
 
 @PhdThesis{Shearer2006,
@@ -357,7 +357,7 @@ year = {2012}
 }
 
 @proceedings{scitech19,
-  title={AIAA SciTech 2019 Forum},
+  title={{AIAA SciTech 2019 Forum}},
   publisher = {American Institute of Aeronautics and Astronautics},
   venue={San Diego, California},
   year={2019}
@@ -411,7 +411,7 @@ eprint = {
   title={Low-Speed Aerodynamics},
   author={Katz, J. and Plotkin, A.},
   isbn={9781107717428},
-  series={Cambridge Aerospace Series},
+  series={{Cambridge Aerospace Series}},
   year={2001},
   publisher={Cambridge University Press}
 }
@@ -466,7 +466,7 @@ eprint = {https://arc.aiaa.org/doi/pdf/10.2514/6.2007-6703}
  @inproceedings{del2019ifasd,
   title={Nonlinear response of a very flexible aircraft under lateal gust},
   author={Del Carre, Alfonso and Teixeira, Patricia, and Cesnik, Carlos E. S. and Palacios, Rafael},
-  booktitle={IFASD 2019 Forum},
+  booktitle={{IFASD 2019 Forum}},
   address={Savannah, Georgia},
   year={2019},
   publisher = {},

--- a/docs/JOSS/paper.bib
+++ b/docs/JOSS/paper.bib
@@ -345,14 +345,22 @@ year = {2012}
   title = {Dynamic Load Alleviation in Wake Vortex Encounters},
   journal = {Journal of Guidance,  Control,  and Dynamics}
  }
- @inproceedings{del2019efficient,
+
+@inproceedings{del2019efficient,
   title={Low-Altitude Dynamics of Very Flexible Aircraft},
   author={Del Carre, Alfonso and Palacios, Rafael},
-  booktitle={AIAA SciTech 2019 Forum},
   address={San Diego, California},
   year={2019},
   publisher = {American Institute of Aeronautics and Astronautics},
-  doi={10.2514/6.2019-2038}
+  doi={10.2514/6.2019-2038},
+  crossref={scitech19}
+}
+
+@proceedings{scitech19,
+  title={AIAA SciTech 2019 Forum},
+  publisher = {American Institute of Aeronautics and Astronautics},
+  venue={San Diego, California},
+  year={2019}
 }
 
 @article{melin2013tornado,

--- a/docs/JOSS/paper.md
+++ b/docs/JOSS/paper.md
@@ -47,7 +47,7 @@ is also trending towards longer and more slender blades, specially for off-shore
 applications, where the largest blades are now close to 100-m long.
 
 
-These longer and much slender structures can present large deflections and have relatively low frequency structural
+These longer and more slender structures can present large deflections and have relatively low frequency structural
 modes which, in the case of aircraft, can interact with the flight dynamics modes with potentially unstable couplings.
 In the case of offshore wind turbines, platform movement may generate important rotor excursions that cause complex
 aeroelastic phenomena which conventional quasi-linear methods may not accurately capture.


### PR DESCRIPTION
Fixes minor typos in JOSS paper, namely:

- Changed `much` to `more` in par.4
- Fixed capitalisation in the bibliography