### PR TITLE
Rework of direct balancing and test

### DIFF
--- a/sharpy/rom/utils/librom.py
+++ b/sharpy/rom/utils/librom.py
@@ -46,9 +46,9 @@ def balreal_direct_py(A, B, C, DLTI=True, Schur=False, full_outputs=False):
     The balanced system is therefore of the form:
 
     .. math::
-        \mathbf{A_b} &= \mathbf{T\,A\,T^{-1}} \\
-        \mathbf{B_b} &= \mathbf{T\,B} \\
-        \mathbf{C_b} &= \mathbf{C\,T^{-1}} \\
+        \mathbf{A_b} &= \mathbf{T^{-1}\,A\,T} \\
+        \mathbf{B_b} &= \mathbf{T^{-1}\,B} \\
+        \mathbf{C_b} &= \mathbf{C\,T} \\
         \mathbf{D_b} &= \mathbf{D}
 
     Warnings:
@@ -57,8 +57,10 @@ def balreal_direct_py(A, B, C, DLTI=True, Schur=False, full_outputs=False):
         in frequency and time.
 
     Notes:
-        Lyapunov equations are solved using Barlets-Stewart algorithm for
-        Sylvester equation, which is based on A matrix Schur decomposition.
+        - Lyapunov equations are solved using Barlets-Stewart algorithm for
+          Sylvester equation, which is based on A matrix Schur decomposition.
+
+        - Notation above is consistent with Gawronski [2].
 
     Args:
         A (np.ndarray): Plant Matrix
@@ -74,8 +76,10 @@ def balreal_direct_py(A, B, C, DLTI=True, Schur=False, full_outputs=False):
             - Inverse transformation matrix(``Tinv``).
 
     References:
-        Anthoulas, A.C.. Approximation of Large Scale Dynamical Systems. Chapter 7. Advances in Design and Control.
+        [1] Anthoulas, A.C.. Approximation of Large Scale Dynamical Systems. Chapter 7. Advances in Design and Control.
         SIAM. 2005.
+
+        [2] Gawronski, W.. Dynamics and control of structures. New York: Springer. 1998
     """
 
     ### select solver for Lyapunov equation
@@ -123,24 +127,73 @@ def balreal_direct_py(A, B, C, DLTI=True, Schur=False, full_outputs=False):
 
     ### Find transformation matrices
     # avoid Cholevski - unstable
-    hsv_sq, Tinv = np.linalg.eig(np.dot(Wc, Wo))
-    T = np.linalg.inv(Tinv)
 
-    # sort
-    iisort = np.argsort(hsv_sq)[::-1]
-    hsv = np.sqrt(hsv_sq[iisort])
-    T = T[:, iisort]
-    Tinv = Tinv[iisort, :]
+    # Added 11/04/2020: Building T and Tinv using SVD:
+    # Perform SVD on grammians:
+    Uc, Sc, Vc = scalg.svd(Wc)
+    Uo, So, Vo = scalg.svd(Wo)
+
+    # Perform decomposition:
+    Sc = np.sqrt(np.diag(Sc))
+    So = np.sqrt(np.diag(So))
+    Qc = Uc @ Sc
+    Qot = So @ Vo
+
+    # Build Hankel matrix:
+    H = Qot @ Qc
+
+    # Find SVD of Hankel matrix:
+    U, hsv, Vt = scalg.svd(H)
+    # hsv = np.diag(hsv)
+
+    # Find T and Tinv:
+    S = np.sqrt(np.diag(hsv))
+
+    # Please note, the notation below is swapped as compared to regular notation in the literature.
+    # This is a known feature of SHARPy, hence it is maintained throughout (including documentation).
+    Tinv = scalg.inv(S) @ U.T @ Qot
+    T = Qc @ Vt.T @ scalg.inv(S)
+
+    # Building T and Tinv using eigenvalues instead:
+    # Note: the method commented out below does not work!
+    #
+    # 11/04/2020
+    #
+    # This section is based on the following idea: given the grammians, one can show that:
+    #
+    # .. math::
+    #     \mathbf{T W_c W_o T}^{-1} = \mathbf{\Sigma}^2
+    #
+    # False proof then left-multiplies by $\mathbf{T}^{-1}$:
+    #
+    # .. math::
+    #     \mathbf{W_c W_o T}^{-1} = \mathbf{T}^{-1} \mathbf{\Sigma}^2
+    #
+    # And argues that since Hankel Singular Value matrix \mathbf{\Sigma} is diagonal, the order of the RHS can be
+    # reversed. This does not actually work, since \mathbf{\Sigma} is not an identity matrix. The section below
+    # is therefore not advised to be used.
+    #
+    # The method does however yield correct Hankel singular values.
+
+    # hsv_sq, Tinv = np.linalg.eig(np.dot(Wc, Wo))
+    # T = np.linalg.inv(Tinv)
+    #
+    # # sort
+    # iisort = np.argsort(hsv_sq)[::-1]
+    # hsv = np.sqrt(hsv_sq[iisort])
+    # T = T[:, iisort]
+    # Tinv = Tinv[iisort, :]
 
     if full_outputs is False:
         return hsv, T, Tinv
 
     else:
         # get square-root factors
-        UT, QoT = scalg.qr(np.dot(np.diag(np.sqrt(hsv)), Tinv), pivoting=False)
-        Vh, QcT = scalg.qr(np.dot(T, np.diag(np.sqrt(hsv))).T, pivoting=False)
+        # UT, QoT = scalg.qr(np.dot(np.diag(np.sqrt(hsv)), Tinv), pivoting=False)
+        # Vh, QcT = scalg.qr(np.dot(T, np.diag(np.sqrt(hsv))).T, pivoting=False)
 
-        return hsv, UT.T, Vh, QcT.T, QoT.T
+        # return hsv, UT.T, Vh, QcT.T, QoT.T
+        return hsv, U, Vt, Qc, Qot.T
 
 
 def balreal_iter(A, B, C, lowrank=True, tolSmith=1e-10, tolSVD=1e-6, kmin=None,

--- a/tests/linear/rom/test_balancing.py
+++ b/tests/linear/rom/test_balancing.py
@@ -20,15 +20,42 @@ class TestBalancing(unittest.TestCase):
         hsv, T, Ti = librom.balreal_direct_py(ss.A, ss.B, ss.C,
                                               DLTI=True, full_outputs=False)
         ssb = copy.deepcopy(ss)
+
+        # Note: notation below is correct and consistent with documentation
+        # SHARPy historically uses notation different from regular literature notation (i.e. 'swapped')
         ssb.project(Ti, T)
 
-        # compare freq. resp.
-        kv = np.array([0., .5, 3., 5.67])
+        # Compare freq. resp. - inconclusive!
+        # The system is consistently transformed using T and Tinv - system dynamics do not change, independent of
+        # choice of T and Tinv. Frequency response will yield the same response:
+        kv = np.linspace(0.01, 10)
         Y = ss.freqresp(kv)
         Yb = ssb.freqresp(kv)
         er_max = np.max(np.abs(Yb - Y))
         assert er_max / np.max(np.abs(Y)) < 1e-10, 'Error too large in frequency response'
 
+        # Compare grammians:
+        Wc = linalg.solve_discrete_lyapunov(ssb.A, np.dot(ssb.B, ssb.B.T))
+        Wo = linalg.solve_discrete_lyapunov(ssb.A.T, np.dot(ssb.C.T, ssb.C))
+
+        er_grammians = np.max(np.abs(Wc - Wo))
+        # Print grammians to compare:
+        if er_grammians / np.max(np.abs(Wc)) > 1e-10:
+            print('Controllability grammian, Wc:\n', Wc)
+            print('Observability grammian, Wo:\n', Wo)
+
+        er_hankel = np.max(np.abs(np.diag(hsv) - Wc))
+        # Print hsv to compare:
+        if er_hankel / np.max(np.abs(Wc)) > 1e-10:
+            print('Controllability grammian, Wc:\n', Wc)
+            print('Hankel values matrix, HSV:\n', hsv)
+
+        assert er_grammians / np.max(np.abs(Wc)) < 1e-10, 'Relative error in Wc-Wo is too large -> Wc != Wo'
+        assert er_hankel / np.max(np.abs(Wc)) < 1e-10, 'Relative error in Wc-HSV is too large -> Wc != HSV'
+
+        # The test below is inconclusive for the direct procedure! T and Tinv are produced from svd(M)
+        # This means that going back from svd(M) to T and Tinv will yield the same result for any choice of T and Tinv
+        # Unless something else is wrong (e.g. a typo) - so leaving it in.
         # test full_outputs option
         hsv, U, Vh, Qc, Qo = librom.balreal_direct_py(ss.A, ss.B, ss.C,
                                                       DLTI=True, full_outputs=True)


### PR DESCRIPTION
Rework includes the following:
1) 'balreal_direct_py' is changed to become correct. Previous solution was based on a false mathematical statement, resulting in incorrect balancing matrices T and Tinv. New formulation is consistent with both Antoulas [1] and Gawronski [2] mathematically, with the notation borrowed from the latter.
2) Documentation part of the code is adjusted to be consistent with the notation in SHARPy and Gawronski [2]. Previous version of documentation had a mistake, where T and Tinv were reversed in the balancing formula. Should be correct now.
Also note, that the present SHARPy notation is actually the inverse of Matlab or Antoulas [1] - T and Tinv are the other way around. Decided not to change that, since too much of the code can rely on current notation.
3) Balancing test is changed. It couldn't previously spot any real mistakes in balancing, independent of what balancing matrices T and Tinv are. Addition of grammian calculation actually allows to compare observability and controllability and check whether they are actually equal.