### PR TITLE
Support to save ROM projector matrices

### DIFF
--- a/sharpy/postproc/savedata.py
+++ b/sharpy/postproc/savedata.py
@@ -58,6 +58,10 @@ class SaveData(BaseSolver):
     settings_description['save_linear_uvlm'] = 'Save linear UVLM state space system. Use with caution when dealing with ' \
                                                'large systems.'
 
+    settings_types['save_rom'] = 'bool'
+    settings_default['save_rom'] = False
+    settings_description['save_rom'] = 'Saves the ROM matrices and the reduced order model'
+
     settings_types['skip_attr'] = 'list(str)'
     settings_default['skip_attr'] = ['fortran',
                                      'airfoils',
@@ -245,7 +249,12 @@ class SaveData(BaseSolver):
                                        ClassesToSave=self.ClassesToSave, SkipAttr=self.settings['skip_attr'],
                                        compress_float=self.settings['compress_float'])
 
-
+            if self.settings['save_rom']:
+                try:
+                    for k, rom in self.data.linear.linear_system.uvlm.rom.items():
+                        rom.save(self.filename.replace('.data.h5', '_{:s}.rom.h5'.format(k.lower())))
+                except AttributeError:
+                    cout.cout_wrap('Could not locate a reduced order model to save')
 
         elif self.settings['format'] == 'mat':
             from scipy.io import savemat

--- a/sharpy/rom/krylov.py
+++ b/sharpy/rom/krylov.py
@@ -10,7 +10,7 @@ import sharpy.utils.rom_interface as rom_interface
 import sharpy.utils.h5utils as h5
 import sharpy.rom.utils.krylovutils as krylovutils
 import warnings as warn
-
+import h5py
 
 @rom_interface.rom
 class Krylov(rom_interface.BaseRom):
@@ -140,6 +140,29 @@ class Krylov(rom_interface.BaseRom):
             self.nfreq = self.frequency.shape[0]
         except AttributeError:
             self.nfreq = 1
+
+    def save(self, filename):
+        """
+        Saves to an ``.h5`` file of name ``filename`` the left and right projectors and the reduced order model
+
+        Args:
+            filename (str): path and filename to which to save the data
+
+        """
+        rom_projectors = {'right_projector': self.V,
+                          'left_projector': self.W,
+                          }
+
+        if '.h5' not in filename[-3:]:
+            filename += '.h5'
+
+        with h5py.File(filename, 'a') as outfile:
+            h5.add_as_grp(rom_projectors, outfile, grpname='projectors',
+                          compress_float=True)
+            h5.add_as_grp(self.ssrom, outfile,
+                          grpname='ssrom',
+                          ClassesToSave=(libss.ss, ),
+                          compress_float=True)
 
     def run(self, ss):
         """

--- a/sharpy/utils/rom_interface.py
+++ b/sharpy/utils/rom_interface.py
@@ -46,6 +46,11 @@ class BaseRom(metaclass=ABCMeta):
     def compare_fom_rom(y1, y2, wv=None, **kwargs):
         return frequencyutils.freqresp_relative_error(y1, y2, wv, **kwargs)
 
+    # Save the ROM matrices to the given filename
+    @abstractmethod
+    def save(self, filename):
+        raise NotImplementedError('Save method for the currently chosen ROM is not yet supported')
+
 
 def rom_from_string(string):
     return dict_of_roms[string]

--- a/sharpy/utils/rom_interface.py
+++ b/sharpy/utils/rom_interface.py
@@ -47,7 +47,6 @@ class BaseRom(metaclass=ABCMeta):
         return frequencyutils.freqresp_relative_error(y1, y2, wv, **kwargs)
 
     # Save the ROM matrices to the given filename
-    @abstractmethod
     def save(self, filename):
         raise NotImplementedError('Save method for the currently chosen ROM is not yet supported')
 

--- a/tests/linear/goland_wing/test_goland_flutter.py
+++ b/tests/linear/goland_wing/test_goland_flutter.py
@@ -81,6 +81,7 @@ class TestGolandFlutter(unittest.TestCase):
                  'LinearAssembler',
                  'FrequencyResponse',
                  'AsymptoticStability',
+                 'SaveData',
                  ],
             'case': ws.case_name, 'route': ws.route,
             'write_screen': 'off', 'write_log': 'on',
@@ -234,6 +235,11 @@ class TestGolandFlutter(unittest.TestCase):
                                           'frequency_spacing': 'log',
                                           'target_system': ['aeroelastic'],
                                           }
+
+        ws.config['SaveData'] = {'folder': self.route_test_dir + '/output/',
+                                 'save_aero': 'off',
+                                 'save_struct': 'off',
+                                 'save_rom': 'on'}
 
         ws.config.write()
 

--- a/tests/linear/rom/test_krylov.py
+++ b/tests/linear/rom/test_krylov.py
@@ -63,6 +63,9 @@ class TestKrylov(unittest.TestCase):
 
         assert np.log10(max_error) < -2, 'Significant mismatch in ROM frequency Response'
 
+        # check saving function
+        self.rom.save(self.test_dir + '/rom_data.h5')
+
     def test_krylov(self):
         algorithm_list = {
             'one_sided_arnoldi':
@@ -82,6 +85,7 @@ class TestKrylov(unittest.TestCase):
     def tearDown(self):
         import shutil
         shutil.rmtree(self.test_dir + '/figs/')
+        os.remove(self.test_dir + '/rom_data.h5')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Small enhancement to `SaveData` postproc that adds a `save_rom` setting that saves the ROM state space as well as the reduced order bases used for reduction.