### PR TITLE
Fix bug in computing total moments in A frame

### DIFF
--- a/.github/workflows/sharpy_tests.yaml
+++ b/.github/workflows/sharpy_tests.yaml
@@ -1,0 +1,55 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up GCC
+        uses: egor-tensin/setup-gcc@v1
+        with:
+          version: 10
+          platform: x64
+      - name: Setup conda
+        uses: s-weigand/setup-conda@v1
+        with:
+          python-version: 3.6
+      - name: Pre-Install dependencies
+        run: |
+          gfortran --version
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+          bash miniconda.sh -b -p $HOME/miniconda
+          export PATH="$HOME/miniconda/bin:$PATH"
+          hash -r
+          conda config --set always_yes yes --set changeps1 no
+          conda update -q conda
+          conda init bash
+          hash -r
+          export QT_QPA_PLATFORM='offscreen'
+          sudo apt install libeigen3-dev
+          conda env create -f utils/environment_minimal.yml
+          conda init bash
+          source activate sharpy_minimal
+          git submodule init
+          git submodule update
+          git fetch -t
+          source bin/sharpy_vars.sh
+          mkdir build && cd build
+          cmake .. && make install -j 4 && cd ..
+          pip install coverage
+          coverage run -m unittest discover
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          verbose: true

--- a/sharpy/aero/utils/mapping.py
+++ b/sharpy/aero/utils/mapping.py
@@ -75,3 +75,34 @@ def aero2struct_force_mapping(aero_forces,
                     struct_forces[i_global_node, 3:6] += np.dot(cbg, algebra.cross3(chi_g, aero_forces[i_surf][0:3, i_m, i_n]))
 
     return struct_forces
+
+
+def total_forces_moments(forces_nodes_a,
+                         pos_def,
+                         ref_pos=np.array([0., 0., 0.])):
+    """
+    Performs a summation of the forces and moments expressed at the structural nodes in the A frame of reference.
+
+    Note:
+        If you need to transform forces and moments at the nodes from B to A, use the
+        :func:`~sharpy.structure.models.beam.Beam.nodal_b_for_2_a_for()` function.
+
+    Args:
+        forces_nodes_a (np.array): ``n_node x 6`` vector of forces and moments at the nodes in A
+        pos_def (np.array): ``n_node x 3`` vector of nodal positions in A
+        ref_pos (np.array (optional)): Location in A about which to compute moments. Defaults to ``[0, 0, 0]``
+
+    Returns:
+        np.array: Vector of length 6 containing the total forces and moments expressed in A at the desired location.
+    """
+
+    num_node = pos_def.shape[0]
+    ra_vec = pos_def - ref_pos
+
+    total_forces = np.zeros(3)
+    total_moments = np.zeros(3)
+    for i_global_node in range(num_node):
+        total_forces += forces_nodes_a[i_global_node, :3]
+        total_moments += forces_nodes_a[i_global_node, 3:] + algebra.cross3(ra_vec[i_global_node], forces_nodes_a[i_global_node, :3])
+
+    return np.concatenate((total_forces, total_moments))

--- a/sharpy/postproc/aeroforcescalculator.py
+++ b/sharpy/postproc/aeroforcescalculator.py
@@ -144,8 +144,15 @@ class AeroForcesCalculator(BaseSolver):
                                                                     self.data.structure.timestep_info[ts])
 
         # Express total forces in A frame
-        self.data.aero.timestep_info[ts].total_steady_body_forces = np.sum(steady_forces_a, axis=0)
-        self.data.aero.timestep_info[ts].total_unsteady_body_forces = np.sum(unsteady_forces_a, axis=0)
+        moment_reference_location = np.array([0., 0., 0.])
+        self.data.aero.timestep_info[ts].total_steady_body_forces = \
+            mapping.total_forces_moments(steady_forces_a,
+                                         self.data.structure.timestep_info[ts].pos,
+                                         ref_pos=moment_reference_location)
+        self.data.aero.timestep_info[ts].total_unsteady_body_forces = \
+            mapping.total_forces_moments(unsteady_forces_a,
+                                         self.data.structure.timestep_info[ts].pos,
+                                         ref_pos=moment_reference_location)
 
         # Express total forces in G frame
         self.data.aero.timestep_info[ts].total_steady_inertial_forces = \


### PR DESCRIPTION
Fixes bug in `AeroforcesCalculator`, where the total moments at the A frame reference location did not include the contribution from the nodal forces, it just summed over the nodal moments.