### PR TITLE
Update installation docs

### DIFF
--- a/docs/source/content/installation.md
+++ b/docs/source/content/installation.md
@@ -129,6 +129,7 @@ change compilers see the Custom Installation.
 
 4. Finally, load the SHARPy variables
     ```bash
+    cd ../
     source bin/sharpy_vars.sh
     ```
 


### PR DESCRIPTION
Added missing directory change after building the repo, to go back one level up from the `build` folder before being able to load the environment variables.