### PR TITLE
Handle absolute tolerance for structural convergence tests as input settings and increase default value

### DIFF
--- a/sharpy/solvers/_basestructural.py
+++ b/sharpy/solvers/_basestructural.py
@@ -36,7 +36,11 @@ class _BaseStructural(BaseSolver):
 
     settings_types['min_delta'] = 'float'
     settings_default['min_delta'] = 1e-5
-    settings_description['min_delta'] = 'Structural solver tolerance'
+    settings_description['min_delta'] = 'Structural solver relative tolerance'
+
+    settings_types['abs_threshold'] = 'float'
+    settings_default['abs_threshold'] = 1e-13
+    settings_description['abs_threshold'] = 'Structural solver absolute tolerance'
 
     settings_types['newmark_damp'] = 'float'
     settings_default['newmark_damp'] = 1e-4

--- a/sharpy/structure/utils/xbeamlib.py
+++ b/sharpy/structure/utils/xbeamlib.py
@@ -38,6 +38,7 @@ class Xbopts(ct.Structure):
                 ("Solution", ct.c_int),
                 ("DeltaCurved", ct.c_double),
                 ("MinDelta", ct.c_double),
+                ("abs_threshold", ct.c_double),
                 ("NewmarkDamp", ct.c_double),
                 ("gravity_on", ct.c_bool),
                 ("gravity", ct.c_double),
@@ -62,6 +63,7 @@ class Xbopts(ct.Structure):
         self.Solution = ct.c_int(111)
         self.DeltaCurved = ct.c_double(1.0e-2)
         self.MinDelta = ct.c_double(1.0e-8)
+        self.abs_threshold = ct.c_double(1.0e-13)
         self.NewmarkDamp = ct.c_double(0.0)
         self.gravity_on = ct.c_bool(False)
         self.gravity = ct.c_double(0.0)
@@ -91,6 +93,7 @@ def cbeam3_solv_nlnstatic(beam, settings, ts):
     xbopts.NumLoadSteps = ct.c_int(settings['num_load_steps'])
     xbopts.DeltaCurved = ct.c_double(settings['delta_curved'])
     xbopts.MinDelta = ct.c_double(settings['min_delta'])
+    xbopts.abs_threshold = ct.c_double(settings['abs_threshold'])
     xbopts.gravity_on = ct.c_bool(settings['gravity_on'])
     xbopts.gravity = ct.c_double(settings['gravity'])
     gravity_vector = np.dot(beam.timestep_info[ts].cag(), settings['gravity_dir'])
@@ -202,6 +205,7 @@ def cbeam3_solv_nlndyn(beam, settings):
     xbopts.NumGauss = ct.c_int(0)
     xbopts.DeltaCurved = ct.c_double(settings['delta_curved'])
     xbopts.MinDelta = ct.c_double(settings['min_delta'])
+    xbopts.abs_threshold = ct.c_double(settings['abs_threshold'])
     xbopts.NewmarkDamp = ct.c_double(settings['newmark_damp'])
     xbopts.gravity_on = ct.c_bool(settings['gravity_on'])
     xbopts.gravity = ct.c_double(settings['gravity'])
@@ -279,6 +283,7 @@ def cbeam3_step_nlndyn(beam, settings, ts, tstep=None, dt=None):
     xbopts.NumGauss = ct.c_int(0)
     xbopts.DeltaCurved = ct.c_double(settings['delta_curved'])
     xbopts.MinDelta = ct.c_double(settings['min_delta'])
+    xbopts.abs_threshold = ct.c_double(settings['abs_threshold'])
     xbopts.NewmarkDamp = ct.c_double(settings['newmark_damp'])
     xbopts.gravity_on = ct.c_bool(settings['gravity_on'])
     xbopts.gravity = ct.c_double(settings['gravity'])
@@ -373,6 +378,7 @@ def xbeam_solv_couplednlndyn(beam, settings):
     # xbopts.NumGauss = ct.c_int(0)
     xbopts.DeltaCurved = ct.c_double(settings['delta_curved'])
     xbopts.MinDelta = ct.c_double(settings['min_delta'])
+    xbopts.abs_threshold = ct.c_double(settings['abs_threshold'])
     xbopts.NewmarkDamp = ct.c_double(settings['newmark_damp'])
     xbopts.gravity_on = ct.c_bool(settings['gravity_on'])
     xbopts.gravity = ct.c_double(settings['gravity'])
@@ -480,6 +486,7 @@ def xbeam_step_couplednlndyn(beam, settings, ts, tstep=None, dt=None):
     xbopts.NumLoadSteps = ct.c_int(settings['num_load_steps'])
     xbopts.DeltaCurved = ct.c_double(settings['delta_curved'])
     xbopts.MinDelta = ct.c_double(settings['min_delta'])
+    xbopts.abs_threshold = ct.c_double(settings['abs_threshold'])
     xbopts.NewmarkDamp = ct.c_double(settings['newmark_damp'])
     xbopts.gravity_on = ct.c_bool(settings['gravity_on'])
     xbopts.gravity = ct.c_double(settings['gravity'])
@@ -555,6 +562,7 @@ def xbeam_init_couplednlndyn(beam, settings, ts, dt=None):
     xbopts.NumLoadSteps = ct.c_int(settings['num_load_steps'])
     xbopts.DeltaCurved = ct.c_double(settings['delta_curved'])
     xbopts.MinDelta = ct.c_double(settings['min_delta'])
+    xbopts.abs_threshold = ct.c_double(settings['abs_threshold'])
     xbopts.NewmarkDamp = ct.c_double(settings['newmark_damp'])
     xbopts.gravity_on = ct.c_bool(settings['gravity_on'])
     xbopts.gravity = ct.c_double(settings['gravity'])
@@ -888,6 +896,7 @@ def cbeam3_asbly_dynamic(beam, tstep, settings):
     xbopts.NumGauss = ct.c_int(0)
     xbopts.DeltaCurved = ct.c_double(settings['delta_curved'])
     xbopts.MinDelta = ct.c_double(settings['min_delta'])
+    xbopts.abs_threshold = ct.c_double(settings['abs_threshold'])
     xbopts.NewmarkDamp = ct.c_double(settings['newmark_damp'])
     xbopts.gravity_on = ct.c_bool(settings['gravity_on'])
     xbopts.gravity = ct.c_double(settings['gravity'])
@@ -991,6 +1000,7 @@ def xbeam3_asbly_dynamic(beam, tstep, settings):
     xbopts.NumGauss = ct.c_int(0)
     xbopts.DeltaCurved = ct.c_double(settings['delta_curved'])
     xbopts.MinDelta = ct.c_double(settings['min_delta'])
+    xbopts.abs_threshold = ct.c_double(settings['abs_threshold'])
     xbopts.NewmarkDamp = ct.c_double(settings['newmark_damp'])
     xbopts.gravity_on = ct.c_bool(settings['gravity_on'])
     xbopts.gravity = ct.c_double(settings['gravity'])
@@ -1203,6 +1213,7 @@ def xbeam_step_coupledrigid(beam, settings, ts, tstep=None, dt=None):
     xbopts.NumLoadSteps = ct.c_int(settings['num_load_steps'])
     xbopts.DeltaCurved = ct.c_double(settings['delta_curved'])
     xbopts.MinDelta = ct.c_double(settings['min_delta'])
+    xbopts.abs_threshold = ct.c_double(settings['abs_threshold'])
     xbopts.NewmarkDamp = ct.c_double(settings['newmark_damp'])
     xbopts.gravity_on = ct.c_bool(settings['gravity_on'])
     xbopts.gravity = ct.c_double(settings['gravity'])


### PR DESCRIPTION
The absolute tolerance used in xbeam for the convergence test is added as a user-defined input to the base structural solver and is passed to xbeam with xbopts. The main reason for the change is a bug in xbeam where the absolute tolerance was defined as too small to be able to catch significant small residuals in convergence tests for which the relative tolerance fails (see https://github.com/ImperialCollegeLondon/xbeam/pull/11). As a result, the structural solver did not converge for the external gust assembler test part of SHARPy's unittest. Further, it has been noticed that the absolute tolerance was defined differently in various functions.

Hence, this pull request includes the following changes:
- define the absolute tolerance for convergence checks within xbeam as a central parameter in xbopts
- increase the default value to catch very small residuals
- allows an adjustment of the absolute tolerance by the user if needed
