### PR TITLE
Minor bug fixes in aero util functions and save data postprocessor

### DIFF
--- a/docs/source/content/example_notebooks/UDP_control/tutorial_udp_control.ipynb
+++ b/docs/source/content/example_notebooks/UDP_control/tutorial_udp_control.ipynb
@@ -2368,18 +2368,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Run SHARPy Simulation\n",
-    "Before running SHARPy, we remove the old linear system generated if existing. It would cause an error that still needs to be fixed (your first contribution?)."
-   ]
-  },
-  {
-   "cell_type": "code",
+    "### Run SHARPy Simulation"
    "execution_count": 22,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if os.path.isfile(os.path.join(output_folder, pazy_model_ROM.case_name, 'savedata', pazy_model_ROM.case_name + '.linss.h5')):\n",
-    "    os.remove(os.path.join(output_folder, pazy_model_ROM.case_name, 'savedata', pazy_model_ROM.case_name + '.linss.h5'))"
    ]
   },
   {

--- a/sharpy/aero/utils/utils.py
+++ b/sharpy/aero/utils/utils.py
@@ -132,8 +132,11 @@ def span_chord(i_node_surf, zeta):
 
 def find_aerodynamic_solver_settings(settings):
     """
-    Retrieves the settings of the first aerodynamic solver used in the solution ``flow``.
-
+    Retrieves the settings of the first aerodynamic solver used in the solution ``flow``. 
+    
+    For coupled solvers, the aerodynamic solver is found in the aero solver settings. 
+    The StaticTrim solver can either contain a coupled or aero solver in its solver 
+    settings (making it into a possible 3-level Matryoshka).
 
     Args:
         settings (dict): SHARPy settings (usually found in ``data.settings`` )
@@ -142,10 +145,12 @@ def find_aerodynamic_solver_settings(settings):
         tuple: Aerodynamic solver settings
     """
     flow = settings['SHARPy']['flow']
-    for solver_name in ['StaticUvlm', 'StaticCoupled', 'DynamicCoupled', 'StepUvlm']:
+    for solver_name in ['StaticUvlm', 'StaticCoupled', 'StaticTrim', 'DynamicCoupled', 'StepUvlm']:
         if solver_name in flow:
             aero_solver_settings = settings[solver_name]
-            if 'aero_solver' in settings[solver_name].keys():
+            if solver_name == 'StaticTrim':
+                aero_solver_settings = aero_solver_settings['solver_settings']['aero_solver_settings']
+            elif 'aero_solver' in settings[solver_name].keys():
                 aero_solver_settings = aero_solver_settings['aero_solver_settings']
                 
             return aero_solver_settings

--- a/sharpy/postproc/savedata.py
+++ b/sharpy/postproc/savedata.py
@@ -152,8 +152,10 @@ class SaveData(BaseSolver):
         self.filename = self.folder + self.data.settings['SHARPy']['case'] + '.data.h5'
         self.filename_linear = self.folder + self.data.settings['SHARPy']['case'] + '.linss.h5'
 
-        if os.path.isfile(self.filename):
-            os.remove(self.filename)
+        # remove old file if it exists
+        for file_path in [self.filename, self.filename_linear]:
+            if os.path.isfile(file_path):
+                os.remove(file_path)
 
         # check that there is a linear system - else return setting to false
         if self.settings['save_linear'] or self.settings['save_linear_uvlm']:


### PR DESCRIPTION
Hey team,

I stumbled across two minor bugs recently that are fixed in this pull request.

The first bug occurs when linearization is performed, but StaticTrim is the only solver used in the SHARPy simulation flow. The reason for this is that the aero solver settings (needed to find the velocity generator settings) cannot be retrieved, because StaticTrim was not previously included as one of the possible solvers. This is now changed.

The second bug causes an error when a linear system is saved but an old file already exists. This file cannot be overwritten, so the old file is now removed (as it was previously already for the nonlinear output file).  I could also remove the workaround for this bug from the UDP tutorial. 

The changes are quite minor and should not take long to review. I have double-checked both fixes myself with simulation examples.
