### PR TITLE
fix [docker] use correct environment name in docker bashrc

### DIFF
--- a/utils/docker/bashrc
+++ b/utils/docker/bashrc
@@ -26,7 +26,7 @@ fi
 unset __conda_setup
 # <<< conda initialize <<<
 
-conda activate sharpy_minimal
+conda activate sharpy
 
 # custom prompt
 PS1="SHARPy> "


### PR DESCRIPTION
We had to adjust also the environment in the bashrc file to make the docker working from the start.