### PR TITLE
Hotfix for documentation - develop

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,10 @@ build:
   tools:
     python: "3.10"
 
+python:
+  install:
+    - requirements: docs/requirements_rtd
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py

--- a/docs/requirements_rtd
+++ b/docs/requirements_rtd
@@ -1,4 +1,4 @@
-sphinx>=3.0
+sphinx>=3.0,<7
 ipykernel
 nbsphinx
 sphinx-rtd-theme==0.5.0

--- a/docs/requirements_rtd
+++ b/docs/requirements_rtd
@@ -2,3 +2,4 @@ sphinx>=3.0
 ipykernel
 nbsphinx
 sphinx-rtd-theme==0.5.0
+recommonmark


### PR DESCRIPTION
necessitated by readthedocs updating the build process
https://docs.readthedocs.io/en/stable/config-file/v2.html#migrating-from-the-web-interface