### PR TITLE
Improve docs and code of newmark_ss

### DIFF
--- a/docs/source/content/installation.md
+++ b/docs/source/content/installation.md
@@ -207,6 +207,10 @@ to your taste.
 
 ## Using SHARPy from a Docker container
 
+> **Tip** To install the Python environment, miniconda needs approximatelly 16GB of
+> memory. It is recommended to have at least that amount available for the
+> container in which you are building SHARPy.
+
 Docker containers are similar to lightweight virtual machines. The SHARPy container
 distributed through [Docker Hub](https://hub.docker.com/) is a CentOS 8
 machine with the libraries compiled with `gfortran` and `g++` and an

--- a/docs/source/content/installation.md
+++ b/docs/source/content/installation.md
@@ -272,13 +272,15 @@ docker cp sharpy:/my_file.txt my_file.txt     # copy from container to host
 ```
 The `sharpy:` part is the `--name` argument you wrote in the `docker run` command.
 
+**Enjoy!**
+
+## Testing with Docker
+
 You can run the test suite once inside the container as:
 ```
 cd sharpy_dir
 python -m unittest
 ```
-
-**Enjoy!**
 
 
 ## Running SHARPy

--- a/docs/source/includes/linear/src/lingebm/newmark_ss.rst
+++ b/docs/source/includes/linear/src/lingebm/newmark_ss.rst
@@ -1,4 +1,4 @@
 newmark_ss
 ----------
 
-.. automodule:: sharpy.linear.src.lingebm.newmark_ss
+.. autofunction:: sharpy.linear.src.lingebm.newmark_ss

--- a/sharpy/linear/src/lingebm.py
+++ b/sharpy/linear/src/lingebm.py
@@ -925,16 +925,10 @@ class FlexDynamic():
                     if self.proj_modes == 'undamped':
                         Phi = self.U[:, :Nmodes]
 
-                        if self.Ccut is None:
-                            # Ccut = np.zeros((Nmodes, Nmodes))
-                            Ccut = np.dot(Phi.T, np.dot(self.Cstr, Phi))
-                        else:
-                            Ccut = np.dot(Phi.T, np.dot(self.Cstr, Phi))
-
                         Ass, Bss, Css, Dss = newmark_ss(
-                            np.dot(self.U[:, :Nmodes].T, np.dot(self.Mstr, self.U[:, :Nmodes])),
-                            Ccut,
-                            np.dot(self.U[:, :Nmodes].T, np.dot(self.Kstr, self.U[:, :Nmodes])),
+                            Phi.T @ self.Mstr @ Phi,
+                            Phi.T @ self.Cstr @ Phi,
+                            Phi.T @ self.Kstr @ Phi,
                             self.dt,
                             self.newmark_damp)
 

--- a/sharpy/linear/src/lingebm.py
+++ b/sharpy/linear/src/lingebm.py
@@ -1399,7 +1399,7 @@ def newmark_ss(Minv, C, K, dt, num_damp=1e-4):
     The following steps describe how to apply the Newmark-beta scheme to a state-space formulation. The original idea
     is based on [1].
 
-    The equation of a second order system dynamics reads:
+    The equation of a second order dynamical system reads:
 
     .. math::
         M\mathbf{\ddot q} + C\mathbf{\dot q} + K\mathbf{q} = F
@@ -1415,7 +1415,7 @@ def newmark_ss(Minv, C, K, dt, num_damp=1e-4):
 
     .. math::
         \mathbf{q}_{n+1} &= \mathbf{q}_n + \mathbf{\dot q}_n\Delta t +
-        (\frac{1}{2}-\beta)\mathbf{\ddot q}_n \Delta t^2 + \beta \mathbf{\ddot q}_{n+1} \Delta t^2 + O(\Delta t^3) \\
+        (1/2-\beta)\mathbf{\ddot q}_n \Delta t^2 + \beta \mathbf{\ddot q}_{n+1} \Delta t^2 + O(\Delta t^3) \\
         \mathbf{\dot q}_{n+1} &= \mathbf{\dot q}_n + (1-\gamma)\mathbf{\ddot q}_n \Delta t +
         \gamma \mathbf{\ddot q}_{n+1} \Delta t + O(\Delta t^3)
 
@@ -1423,8 +1423,8 @@ def newmark_ss(Minv, C, K, dt, num_damp=1e-4):
 
     .. math::
         \begin{bmatrix} 
-            I + M^{-1}K \Delta t^2\beta & \Delta t^2\beta M^{-1}C \\ 
-            (\gamma \Delta t M^{-1}K)   & (I + \gamma \Delta t M^{-1}C) 
+            I + \beta\Delta t^2 M^{-1}K & \beta\Delta t^2 M^{-1}C \\ 
+            \gamma \Delta t M^{-1}K     & I + \gamma \Delta t M^{-1}C 
         \end{bmatrix} 
         \begin{Bmatrix} 
             \mathbf{q}_{n+1} \\
@@ -1432,33 +1432,34 @@ def newmark_ss(Minv, C, K, dt, num_damp=1e-4):
         \end{Bmatrix} 
         =
         \begin{bmatrix} 
-            (I - \Delta t^2(1/2-\beta)M^{-1}K & (\Delta t - \Delta t^2(1/2-\beta)M^{-1}C \\
-            (-(1-\gamma)\Delta t M^{-1}K      & (I - (1-\gamma)\Delta tM^{-1}C 
+            I - \Delta t^2(1/2-\beta)M^{-1}K  & \Delta t I - (1/2-\beta)\Delta t^2 M^{-1}C \\
+            -(1-\gamma)\Delta t M^{-1}K       &  I - (1-\gamma)\Delta t M^{-1}C
         \end{bmatrix}
         \begin{Bmatrix}  
             \mathbf{q}_{n} \\ \
             mathbf{\dot q}_{n} 
         \end{Bmatrix}	
         +
-        \begin{Bmatrix} 
-            (\Delta t^2(1/2-\beta) \\ 
-            (1-\gamma)\Delta t 
-        \end{Bmatrix} 
-        M^{-1}F_n+
-        \begin{Bmatrix} 
-            (\Delta t^2\beta) \\ 
-            (\gamma \Delta t) 
-        \end{Bmatrix}M^{-1}F_{n+1}
+        \begin{bmatrix} 
+            (\Delta t^2(1/2-\beta)\, M^{-1} \\ 
+            (1-\gamma)\Delta t \, M^{-1}
+        \end{bmatrix} 
+        F_n +
+        \begin{bmatrix} 
+            (\beta \Delta t^2) \, M^{-1}\\ 
+            (\gamma \Delta t)  \, M^{-1}
+        \end{bmatrix}
+        F_{n+1}
 
     To understand SHARPy code, it is convenient to apply the following change of notation:
 
     .. math::
         \textrm{th1} = \gamma \\
         \textrm{th2} = \beta \\
-        \textrm{a0} = \Delta t^2 (1/2 -\beta) \\
-        \textrm{b0} = \Delta t (1 -\gamma) \\
-        \textrm{a1} = \Delta t^2 \beta \\
-        \textrm{b1} = \Delta t \gamma \\
+        \textrm{a0} = (1/2 -\beta) \Delta t^2  \\
+        \textrm{b0} = (1 -\gamma) \Delta t \\
+        \textrm{a1} = \beta \Delta t^2 \\
+        \textrm{b1} =  \gamma \Delta t \\
 
     Finally:
 

--- a/sharpy/linear/src/lingebm.py
+++ b/sharpy/linear/src/lingebm.py
@@ -1451,16 +1451,6 @@ def newmark_ss(Minv, C, K, dt, num_damp=1e-4):
         \end{bmatrix}
         F_{n+1}
 
-    To understand SHARPy code, it is convenient to apply the following change of notation:
-
-    .. math::
-        \textrm{th1} = \gamma \\
-        \textrm{th2} = \beta \\
-        \textrm{a0} = (1/2 -\beta) \Delta t^2  \\
-        \textrm{b0} = (1 -\gamma) \Delta t \\
-        \textrm{a1} = \beta \Delta t^2 \\
-        \textrm{b1} =  \gamma \Delta t \\
-
     Finally:
 
     .. math::
@@ -1471,6 +1461,16 @@ def newmark_ss(Minv, C, K, dt, num_damp=1e-4):
 
     To finally isolate the vector at :math:`n+1`, instead of inverting the :math:`A_{ss1}` matrix, several systems are
     solved. Moreover, the output equation is simply :math:`y=x`.
+
+    To understand SHARPy code, it is convenient to apply the following change of notation:
+    
+        .. math::
+            \textrm{th1} = \gamma \\
+            \textrm{th2} = \beta \\
+            \textrm{a0} = (1/2 -\beta) \Delta t^2  \\
+            \textrm{b0} = (1 -\gamma) \Delta t \\
+            \textrm{a1} = \beta \Delta t^2 \\
+            \textrm{b1} =  \gamma \Delta t \\
 
     Args:
         Minv (np.array): Inverse mass matrix :math:`\mathbf{M^{-1}}`

--- a/sharpy/linear/src/lingebm.py
+++ b/sharpy/linear/src/lingebm.py
@@ -1422,14 +1422,33 @@ def newmark_ss(Minv, C, K, dt, num_damp=1e-4):
     Substituting the former relation onto the later ones, rearranging terms, and writing it in state-space form:
 
     .. math::
-        \begin{bmatrix} I + M^{-1}K \Delta t^2\beta \quad \Delta t^2\beta M^{-1}C \\ (\gamma \Delta t M^{-1}K)
-        \quad (I + \gamma \Delta t M^{-1}C) \end{bmatrix} \begin{Bmatrix} \mathbf{\dot q}_{n+1} \\
-        \mathbf{\ddot q}_{n+1} \end{Bmatrix} =
-        \begin{bmatrix} (I - \Delta t^2(1/2-\beta)M^{-1}K \quad (\Delta t - \Delta t^2(1/2-\beta)M^{-1}C \\
-        (-(1-\gamma)\Delta t M^{-1}K \quad (I - (1-\gamma)\Delta tM^{-1}C \end{bmatrix}
-        \begin{Bmatrix}  \mathbf{q}_{n} \\ \mathbf{\dot q}_{n} \end{Bmatrix}	+
-        \begin{Bmatrix} (\Delta t^2(1/2-\beta) \\ (1-\gamma)\Delta t \end{Bmatrix} M^{-1}F_n+
-        \begin{Bmatrix} (\Delta t^2\beta) \\ (\gamma \Delta t) \end{Bmatrix}M^{-1}F_{n+1}
+        \begin{bmatrix} 
+            I + M^{-1}K \Delta t^2\beta & \Delta t^2\beta M^{-1}C \\ 
+            (\gamma \Delta t M^{-1}K)   & (I + \gamma \Delta t M^{-1}C) 
+        \end{bmatrix} 
+        \begin{Bmatrix} 
+            \mathbf{\dot q}_{n+1} \\
+            \mathbf{\ddot q}_{n+1} 
+        \end{Bmatrix} 
+        =
+        \begin{bmatrix} 
+            (I - \Delta t^2(1/2-\beta)M^{-1}K & (\Delta t - \Delta t^2(1/2-\beta)M^{-1}C \\
+            (-(1-\gamma)\Delta t M^{-1}K      & (I - (1-\gamma)\Delta tM^{-1}C 
+        \end{bmatrix}
+        \begin{Bmatrix}  
+            \mathbf{q}_{n} \\ \
+            mathbf{\dot q}_{n} 
+        \end{Bmatrix}	
+        +
+        \begin{Bmatrix} 
+            (\Delta t^2(1/2-\beta) \\ 
+            (1-\gamma)\Delta t 
+        \end{Bmatrix} 
+        M^{-1}F_n+
+        \begin{Bmatrix} 
+            (\Delta t^2\beta) \\ 
+            (\gamma \Delta t) 
+        \end{Bmatrix}M^{-1}F_{n+1}
 
     To understand SHARPy code, it is convenient to apply the following change of notation:
 

--- a/sharpy/linear/src/lingebm.py
+++ b/sharpy/linear/src/lingebm.py
@@ -1348,28 +1348,22 @@ class FlexDynamic():
 
 def newmark_ss(M, C, K, dt, num_damp=1e-4, M_is_SPD=False):
     r"""
-    Produces a discrete-time state-space model of the structural equations
-
+    Produces a discrete-time state-space model of the 2nd order ordinary differential equation (ODE) given by
     .. math::
+        \mathbf{M}\mathbf{\ddot{x}} + \mathbf{C}\mathbf{\dot{x}} + \mathbf{K}\mathbf{x} = \mathbf{F}
 
-        \mathbf{\ddot{x}} &= \mathbf{M}^{-1}( -\mathbf{C}\,\mathbf{\dot{x}}-\mathbf{K}\,\mathbf{x}+\mathbf{F} ) \\
-        \mathbf{y} &= \mathbf{x}
+    This ODE is discretized based on the Newmark-:math:`\beta` integration scheme.
 
-
-    based on the Newmark-:math:`\beta` integration scheme. The output state-space model
-    has form:
-
+    The output state-space model has the form:
     .. math::
-
         \mathbf{X}_{n+1} &= \mathbf{A}\,\mathbf{X}_n + \mathbf{B}\,\mathbf{F}_n \\
         \mathbf{Y} &= \mathbf{C}\,\mathbf{X} + \mathbf{D}\,\mathbf{F}
 
-
-    with :math:`\mathbf{X} = [\mathbf{x}, \mathbf{\dot{x}}]^T`
+    with :math:`\mathbf{Y} = [\mathbf{x}, \mathbf{\dot{x}}]^T`
 
     Note that as the state-space representation only requires the input force
-    :math:`\mathbf{F}` to be evaluated at time-step :math:`n`,the :math:`\mathbf{C}` and :math:`\mathbf{D}` matrices
-    are, in general, fully populated.
+    :math:`\mathbf{F}` to be evaluated at time-step :math:`n`, thus the pass-through matrix 
+    :math:`\mathbf{D}` is not zero.
 
     The Newmark-:math:`\beta` integration scheme is carried out following the modifications presented by
     Geradin [1] that render it unconditionally stable. The displacement and velocities are estimated as:
@@ -1464,6 +1458,11 @@ def newmark_ss(M, C, K, dt, num_damp=1e-4, M_is_SPD=False):
 
     see also libss.conv for more details on the elimination of the term
     multiplying ..math:`F_{n+1}` in the state equation.
+
+    This system is identified with a standard discrete state space model
+    ..math::
+        X_{n+1} = A X_n + B F_n
+        Y_n = C X_n + D F_n
 
     This function retuns a tuple with the discrete state-space matrices ..math:` (A,B,C,D)` where
     ..math::

--- a/sharpy/linear/src/lingebm.py
+++ b/sharpy/linear/src/lingebm.py
@@ -1508,10 +1508,12 @@ def newmark_ss(Minv, C, K, dt, num_damp=1e-4):
                      [-b0 * MinvK, Imat - b0 * MinvC]])
     Ass1 = np.block([[Imat + a1 * MinvK, a1 * MinvC],
                      [b1 * MinvK, Imat + b1 * MinvC]])
-    Ass = np.linalg.solve(Ass1, Ass0)
 
-    Bss0 = np.linalg.solve(Ass1, np.block([[a0 * Minv], [b0 * Minv]]))
-    Bss1 = np.linalg.solve(Ass1, np.block([[a1 * Minv], [b1 * Minv]]))
+    # Factorize Ass1 once, solve multiple times
+    Ass1_factors = sc.linalg.lu_factor(Ass1)
+    Ass = sc.linalg.lu_solve(Ass1_factors, Ass0)
+    Bss0 = sc.linalg.lu_solve(Ass1_factors, np.block([[a0 * Minv], [b0 * Minv]]))
+    Bss1 = sc.linalg.lu_solve(Ass1_factors, np.block([[a1 * Minv], [b1 * Minv]]))
 
     # eliminate predictior term Bss1
     return libss.SSconv(Ass, Bss0, Bss1, C=np.eye(2 * N), D=np.zeros((2 * N, N)))

--- a/sharpy/linear/src/lingebm.py
+++ b/sharpy/linear/src/lingebm.py
@@ -1427,8 +1427,8 @@ def newmark_ss(Minv, C, K, dt, num_damp=1e-4):
             (\gamma \Delta t M^{-1}K)   & (I + \gamma \Delta t M^{-1}C) 
         \end{bmatrix} 
         \begin{Bmatrix} 
-            \mathbf{\dot q}_{n+1} \\
-            \mathbf{\ddot q}_{n+1} 
+            \mathbf{q}_{n+1} \\
+            \mathbf{\dot q}_{n+1} 
         \end{Bmatrix} 
         =
         \begin{bmatrix} 

--- a/tests/linear/rom/test_springmasssystem.py
+++ b/tests/linear/rom/test_springmasssystem.py
@@ -134,7 +134,7 @@ class TestKrylovRom(unittest.TestCase):
         else:
             # Discrete time system
             dt = 1e-2
-            Adt, Bdt, Cdt, Ddt = lingebm.newmark_ss(Minv, C, k, dt=dt, num_damp=0)
+            Adt, Bdt, Cdt, Ddt = lingebm.newmark_ss(m, C, k, dt=dt, num_damp=0)
 
             system = libss.StateSpace(Adt, Bdt, Cdt, Ddt, dt=dt)
 


### PR DESCRIPTION
## Changes in the documentation of `newmark_ss`
I spotted some small errors in the documentation of the `newmark_ss` function (the code was ok!) and I decided to improve them since this is a pretty good tutorial on the method that may be useful for my team as well. Therefore I did some improvements such as
- Correcting mistakes such as missed parenthesis; extra derivative dots; etc.
- Making the notation more uniform: C was used for both the damping matrix and the state-space C matrix; q and x were used for the position interchangeably; now all matrices are bold upper-case and vectors are bold lower-case.

## Changes in the code of `newmark_ss`
I tried to make the code slightly faster and more accurate by reusing the factorization of the Ass1 matrix and by using the factorization of the M matrix to compute the multiplication by the inverse (due to the triangular structure of the factorization this is both faster and more accurate). *This caused a change in the function arguments since it now takes the M matrix instead of its inverse*. I also added the option to factorize the M matrix using Cholesky, but I did not enable that option since I am not familiar enough with SHARPy's theory to be 100% sure that the M matrix is symmetric positive definite. *I would like to ask the core developers to consider enabling that option on the calls to `newmark_ss`*. It has better numerical properties than the LU decomposition. I cleaned up some dead code close to the other changes I made and replaced some of the usages of `np.dot` by `@` for matrix multiplication, since this is a NumPy best practice.

## Changes in the installation documentation
I did some small additions to the installation with Docker section that I found useful when I used it for testing:
- I added a tip suggesting at least 16GB of RAM for the Docker container. My computer defaulted to 8GB which was not enough and I had an out-of-memory error
- I separated the procedures for testing so that it is easier to find. The installation with Docker was so easy that I did not even have to read the instructions, and then I did not see that! Kudos to the developers!

## Testing of the changes
I tested the changes on Docker, and I am pasting the output below. I believe all tests passed but I would like to double check if the warnings are expected.

```
SHARPy> git log -1
commit db53dcfd85389b6cb8491ad63b7c2a5b4cd9b7aa (HEAD -> linear, origin/linear)
Author: Bernardo Bahia Monteiro <bbahia@umich.edu>
Date:   Fri Oct 27 22:48:56 2023 +0000

    [docs] Create section for testing in Docker so it is easier to find
SHARPy> git status
On branch linear
Your branch is up to date with 'origin/linear'.

nothing to commit, working tree clean
SHARPy> cd /sharpy_dir/ && python -m unittest
running unittest
fatal: No names found, cannot describe anything.
running unittest
fatal: No names found, cannot describe anything.
.fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/structure/models/beam.py:547: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  ibody_beam.connectivities[ielem, inode_in_elem] = int_list_nodes[ibody_nodes == ibody_beam.connectivities[ielem, inode_in_elem]]
fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/structure/models/beam.py:547: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  ibody_beam.connectivities[ielem, inode_in_elem] = int_list_nodes[ibody_nodes == ibody_beam.connectivities[ielem, inode_in_elem]]
.fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/structure/models/beam.py:547: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  ibody_beam.connectivities[ielem, inode_in_elem] = int_list_nodes[ibody_nodes == ibody_beam.connectivities[ielem, inode_in_elem]]
.fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/structure/models/beam.py:547: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  ibody_beam.connectivities[ielem, inode_in_elem] = int_list_nodes[ibody_nodes == ibody_beam.connectivities[ielem, inode_in_elem]]
.fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/structure/models/beam.py:547: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  ibody_beam.connectivities[ielem, inode_in_elem] = int_list_nodes[ibody_nodes == ibody_beam.connectivities[ielem, inode_in_elem]]
.fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/structure/models/beam.py:547: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  ibody_beam.connectivities[ielem, inode_in_elem] = int_list_nodes[ibody_nodes == ibody_beam.connectivities[ielem, inode_in_elem]]
./miniconda3/envs/sharpy/lib/python3.10/xml/etree/ElementTree.py:1651: ResourceWarning: unclosed file <_io.BufferedReader name='/sharpy_dir/tests/coupled/prescribed/WindTurbine/../../../../docs/source/content/example_notebooks/source/type04_db_nrel5mw_oc3_v06.xlsx'>
  return self.target.start(tag, attrib)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
fatal: No names found, cannot describe anything.
.sfatal: No names found, cannot describe anything.
.fatal: No names found, cannot describe anything.
False
.fatal: No names found, cannot describe anything.
False
.fatal: No names found, cannot describe anything.
False
.fatal: No names found, cannot describe anything.
False
.fatal: No names found, cannot describe anything.
.............fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
/sharpy_dir/sharpy/linear/src/lingebm.py:313: UserWarning: Euler parametrisation not implemented - Either rigid body modes are not being used or this method has already been called.
  warnings.warn('Euler parametrisation not implemented - Either rigid body modes are not being used or this '
/sharpy_dir/sharpy/solvers/lindynamicsim.py:164: UserWarning: Number of states in the initial state vector not equal to the number of states
  warnings.warn('Number of states in the initial state vector not equal to the number of states')
.....fatal: No names found, cannot describe anything.
False
/sharpy_dir/sharpy/structure/utils/modalutils.py:469: ComplexWarning: Casting complex values to real discards the imaginary part
  phi_rr[:, index_mode] = eigenvectors[-num_rigid_modes:, i]
/sharpy_dir/sharpy/linear/src/lingebm.py:1019: ComplexWarning: Casting complex values to real discards the imaginary part
  Ass[Nmodes:, Nmodes:] = -self.Ccut[:Nmodes, :Nmodes]
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
/sharpy_dir/sharpy/solvers/modal.py:269: UserWarning: Projecting a system with damping on undamped modal shapes
  warnings.warn('Projecting a system with damping on undamped modal shapes')
/sharpy_dir/sharpy/structure/utils/modalutils.py:469: ComplexWarning: Casting complex values to real discards the imaginary part
  phi_rr[:, index_mode] = eigenvectors[-num_rigid_modes:, i]
/sharpy_dir/sharpy/linear/src/lingebm.py:1019: ComplexWarning: Casting complex values to real discards the imaginary part
  Ass[Nmodes:, Nmodes:] = -self.Ccut[:Nmodes, :Nmodes]
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
fatal: No names found, cannot describe anything.
False
..fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/zipfile.py:1821: ResourceWarning: unclosed file <_io.BufferedReader name='/sharpy_dir/tests/coupled/prescribed/WindTurbine/../../../../docs/source/content/example_notebooks/source/type04_db_nrel5mw_oc3_v06.xlsx'>
  self.close()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/miniconda3/envs/sharpy/lib/python3.10/ctypes/__init__.py:510: ResourceWarning: unclosed file <_io.BufferedReader name='/sharpy_dir/tests/coupled/prescribed/WindTurbine/../../../../docs/source/content/example_notebooks/source/type04_db_nrel5mw_oc3_v06.xlsx'>
  return _cast(obj, obj, typ)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
/sharpy_dir/sharpy/linear/src/lingebm.py:313: UserWarning: Euler parametrisation not implemented - Either rigid body modes are not being used or this method has already been called.
  warnings.warn('Euler parametrisation not implemented - Either rigid body modes are not being used or this '
.fatal: No names found, cannot describe anything.
False
/sharpy_dir/sharpy/linear/src/lingebm.py:313: UserWarning: Euler parametrisation not implemented - Either rigid body modes are not being used or this method has already been called.
  warnings.warn('Euler parametrisation not implemented - Either rigid body modes are not being used or this '
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/signal/_signaltools.py:1657: RuntimeWarning: divide by zero encountered in divide
  res *= (1 - noise / lVar)
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/signal/_signaltools.py:1657: RuntimeWarning: invalid value encountered in multiply
  res *= (1 - noise / lVar)
.fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
/sharpy_dir/sharpy/linear/src/lingebm.py:313: UserWarning: Euler parametrisation not implemented - Either rigid body modes are not being used or this method has already been called.
  warnings.warn('Euler parametrisation not implemented - Either rigid body modes are not being used or this '
/sharpy_dir/sharpy/solvers/lindynamicsim.py:164: UserWarning: Number of states in the initial state vector not equal to the number of states
  warnings.warn('Number of states in the initial state vector not equal to the number of states')
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
/sharpy_dir/sharpy/linear/src/lingebm.py:313: UserWarning: Euler parametrisation not implemented - Either rigid body modes are not being used or this method has already been called.
  warnings.warn('Euler parametrisation not implemented - Either rigid body modes are not being used or this '
/sharpy_dir/sharpy/solvers/lindynamicsim.py:164: UserWarning: Number of states in the initial state vector not equal to the number of states
  warnings.warn('Number of states in the initial state vector not equal to the number of states')
..fatal: No names found, cannot describe anything.
False
/sharpy_dir/sharpy/aero/utils/uvlmlib.py:213: RuntimeWarning: invalid value encountered in divide
  self.uinf_direction = np.ctypeslib.as_ctypes(vec_u_inf/self.uinf)
/sharpy_dir/sharpy/solvers/modal.py:269: UserWarning: Projecting a system with damping on undamped modal shapes
  warnings.warn('Projecting a system with damping on undamped modal shapes')
..fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/rom/krylov.py:268: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  cout.cout_wrap(self.nfreq * '\t\tsigma = %4f [rad/s]\n' % self.frequency, 1)
/sharpy_dir/sharpy/rom/utils/krylovutils.py:164: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  H[0, 0] = alpha
.fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/linear/src/lingebm.py:313: UserWarning: Euler parametrisation not implemented - Either rigid body modes are not being used or this method has already been called.
  warnings.warn('Euler parametrisation not implemented - Either rigid body modes are not being used or this '
fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/linear/src/lingebm.py:313: UserWarning: Euler parametrisation not implemented - Either rigid body modes are not being used or this method has already been called.
  warnings.warn('Euler parametrisation not implemented - Either rigid body modes are not being used or this '
partitioning: 0.800 to 3.542
partitioning: 3.542 to 6.283
fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/linear/src/lingebm.py:313: UserWarning: Euler parametrisation not implemented - Either rigid body modes are not being used or this method has already been called.
  warnings.warn('Euler parametrisation not implemented - Either rigid body modes are not being used or this '
...sss.x....../miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
.....deep-copying state-space model before scaling
deep-copying state-space model before scaling
...........fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
/miniconda3/envs/sharpy/lib/python3.10/site-packages/scipy/sparse/_index.py:143: SparseEfficiencyWarning: Changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
  self._set_arrayXarray(i, j, x)
fatal: No names found, cannot describe anything.
.fatal: No names found, cannot describe anything.
.fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
.fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
.........../miniconda3/envs/sharpy/lib/python3.10/xml/etree/ElementTree.py:1651: ResourceWarning: unclosed file <_io.BufferedReader name='/sharpy_dir/tests/utils/../../docs/source/content/example_notebooks/source/type04_db_nrel5mw_oc3_v06.xlsx'>
  return self.target.start(tag, attrib)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
fatal: No names found, cannot describe anything.
.fatal: No names found, cannot describe anything.
..fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/generators/polaraeroforces.py:233: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  forces_s[0] += cd * coef  # add viscous drag to induced drag from UVLM
/sharpy_dir/sharpy/generators/polaraeroforces.py:234: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  forces_s[2] = cl * coef
/sharpy_dir/sharpy/generators/polaraeroforces.py:244: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] += cm * coef * chord
/sharpy_dir/sharpy/generators/polaraeroforces.py:259: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] += cm * coef * chord
/sharpy_dir/sharpy/generators/polaraeroforces.py:271: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] = cm * coef * chord
False
fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/generators/polaraeroforces.py:233: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  forces_s[0] += cd * coef  # add viscous drag to induced drag from UVLM
/sharpy_dir/sharpy/generators/polaraeroforces.py:234: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  forces_s[2] = cl * coef
/sharpy_dir/sharpy/generators/polaraeroforces.py:244: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] += cm * coef * chord
/sharpy_dir/sharpy/generators/polaraeroforces.py:259: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] += cm * coef * chord
/sharpy_dir/sharpy/generators/polaraeroforces.py:271: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] = cm * coef * chord
False
fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/generators/polaraeroforces.py:233: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  forces_s[0] += cd * coef  # add viscous drag to induced drag from UVLM
/sharpy_dir/sharpy/generators/polaraeroforces.py:234: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  forces_s[2] = cl * coef
/sharpy_dir/sharpy/generators/polaraeroforces.py:244: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] += cm * coef * chord
/sharpy_dir/sharpy/generators/polaraeroforces.py:259: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] += cm * coef * chord
/sharpy_dir/sharpy/generators/polaraeroforces.py:271: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] = cm * coef * chord
False
fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/generators/polaraeroforces.py:233: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  forces_s[0] += cd * coef  # add viscous drag to induced drag from UVLM
/sharpy_dir/sharpy/generators/polaraeroforces.py:234: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  forces_s[2] = cl * coef
/sharpy_dir/sharpy/generators/polaraeroforces.py:244: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] += cm * coef * chord
/sharpy_dir/sharpy/generators/polaraeroforces.py:259: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] += cm * coef * chord
/sharpy_dir/sharpy/generators/polaraeroforces.py:271: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] = cm * coef * chord
False
fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/generators/polaraeroforces.py:233: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  forces_s[0] += cd * coef  # add viscous drag to induced drag from UVLM
/sharpy_dir/sharpy/generators/polaraeroforces.py:234: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  forces_s[2] = cl * coef
/sharpy_dir/sharpy/generators/polaraeroforces.py:244: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] += cm * coef * chord
/sharpy_dir/sharpy/generators/polaraeroforces.py:259: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] += cm * coef * chord
/sharpy_dir/sharpy/generators/polaraeroforces.py:271: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] = cm * coef * chord
False
fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/generators/polaraeroforces.py:233: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  forces_s[0] += cd * coef  # add viscous drag to induced drag from UVLM
/sharpy_dir/sharpy/generators/polaraeroforces.py:234: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  forces_s[2] = cl * coef
/sharpy_dir/sharpy/generators/polaraeroforces.py:244: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] += cm * coef * chord
/sharpy_dir/sharpy/generators/polaraeroforces.py:259: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] += cm * coef * chord
/sharpy_dir/sharpy/generators/polaraeroforces.py:271: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  moment_s[1] = cm * coef * chord
False
..fatal: No names found, cannot describe anything.
/sharpy_dir/sharpy/structure/models/beam.py:422: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  self.fortran['num_mem'][elem.ielem] = elem.num_mem
.
----------------------------------------------------------------------
Ran 90 tests in 446.537s

OK (skipped=4, expected failures=1)
```