### PR TITLE
Update XBeam version to include compiler optimisation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN mamba config --set always_yes yes --set changeps1 no
 RUN mamba update -q conda
 RUN mamba config --set auto_activate_base false
 RUN mamba env create -f /sharpy_dir/utils/environment.yml && mamba clean -afy && \
-
     find /mamba/ -follow -type f -name '*.a' -delete && \
     find /mamba/ -follow -type f -name '*.pyc' -delete && \
     find /mamba/ -follow -type f -name '*.js.map' -delete

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,15 @@ ADD / /sharpy_dir/
 # Cleanup mamba installation
 RUN mamba init bash
 RUN mamba config --set always_yes yes --set changeps1 no
-RUN mamba update -q conda
+#RUN mamba update -q conda
+RUN mamda update --all
 RUN mamba config --set auto_activate_base false
 #RUN mamba env create -f /sharpy_dir/utils/environment.yml && mamba clean -afy && \
 #    find /mamba/ -follow -type f -name '*.a' -delete && \
 #    find /mamba/ -follow -type f -name '*.pyc' -delete && \
 #    find /mamba/ -follow -type f -name '*.js.map' -delete
 RUN mamba env create -f /sharpy_dir/utils/environment.yml
-RUN mamba clean
+RUN mamba clean -afy
 RUN find /mamba/ -follow -type f -name '*.a' -delete
 RUN find /mamba/ -follow -type f -name '*.pyc' -delete
 RUN find /mamba/ -follow -type f -name '*.js.map' -delete

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN mamba config --set auto_activate_base false
 #    find /mamba/ -follow -type f -name '*.a' -delete && \
 #    find /mamba/ -follow -type f -name '*.pyc' -delete && \
 #    find /mamba/ -follow -type f -name '*.js.map' -delete
-RUN mamba env create -f /sharpy_dir/utils/environment.yml && mamba clean -afy
+RUN mamba env create -f /sharpy_dir/utils/environment.yml
+RUN mamba clean -afy
 RUN find /mamba/ -follow -type f -name '*.a' -delete
 RUN find /mamba/ -follow -type f -name '*.pyc' -delete
 RUN find /mamba/ -follow -type f -name '*.js.map' -delete

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,14 @@ RUN mamba init bash
 RUN mamba config --set always_yes yes --set changeps1 no
 RUN mamba update -q conda
 RUN mamba config --set auto_activate_base false
-RUN mamba env create -f /sharpy_dir/utils/environment.yml && mamba clean -afy && \
-    find /mamba/ -follow -type f -name '*.a' -delete && \
-    find /mamba/ -follow -type f -name '*.pyc' -delete && \
-    find /mamba/ -follow -type f -name '*.js.map' -delete
+#RUN mamba env create -f /sharpy_dir/utils/environment.yml && mamba clean -afy && \
+#    find /mamba/ -follow -type f -name '*.a' -delete && \
+#    find /mamba/ -follow -type f -name '*.pyc' -delete && \
+#    find /mamba/ -follow -type f -name '*.js.map' -delete
+RUN mamba env create -f /sharpy_dir/utils/environment.yml && mamba clean -afy
+RUN find /mamba/ -follow -type f -name '*.a' -delete
+RUN find /mamba/ -follow -type f -name '*.pyc' -delete
+RUN find /mamba/ -follow -type f -name '*.js.map' -delete
 
 #COPY /utils/docker/* /root/
 RUN ln -s /sharpy_dir/utils/docker/* /root/

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN mamba config --set auto_activate_base false
 #    find /mamba/ -follow -type f -name '*.pyc' -delete && \
 #    find /mamba/ -follow -type f -name '*.js.map' -delete
 RUN mamba env create -f /sharpy_dir/utils/environment.yml
-RUN mamba clean -afy
+#RUN mamba clean -afy
 RUN find /mamba/ -follow -type f -name '*.a' -delete
 RUN find /mamba/ -follow -type f -name '*.pyc' -delete
 RUN find /mamba/ -follow -type f -name '*.js.map' -delete

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,10 @@ ADD / /sharpy_dir/
 # Cleanup mamba installation
 RUN mamba init bash
 RUN mamba config --set always_yes yes --set changeps1 no
-#RUN mamba update -q conda
-RUN mamba update --all
+RUN mamba update -q conda
 RUN mamba config --set auto_activate_base false
-#RUN mamba env create -f /sharpy_dir/utils/environment.yml && mamba clean -afy && \
-#    find /mamba/ -follow -type f -name '*.a' -delete && \
-#    find /mamba/ -follow -type f -name '*.pyc' -delete && \
-#    find /mamba/ -follow -type f -name '*.js.map' -delete
 RUN mamba env create -f /sharpy_dir/utils/environment.yml
-RUN mamba clean -afy
+#RUN mamba clean -afy
 RUN find /mamba/ -follow -type f -name '*.a' -delete
 RUN find /mamba/ -follow -type f -name '*.pyc' -delete
 RUN find /mamba/ -follow -type f -name '*.js.map' -delete

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN mamba config --set auto_activate_base false
 #    find /mamba/ -follow -type f -name '*.pyc' -delete && \
 #    find /mamba/ -follow -type f -name '*.js.map' -delete
 RUN mamba env create -f /sharpy_dir/utils/environment.yml
-#RUN mamba clean -afy
+RUN mamba clean
 RUN find /mamba/ -follow -type f -name '*.a' -delete
 RUN find /mamba/ -follow -type f -name '*.pyc' -delete
 RUN find /mamba/ -follow -type f -name '*.js.map' -delete

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ADD / /sharpy_dir/
 RUN mamba init bash
 RUN mamba config --set always_yes yes --set changeps1 no
 #RUN mamba update -q conda
-RUN mamda update --all
+RUN mamba update --all
 RUN mamba config --set auto_activate_base false
 #RUN mamba env create -f /sharpy_dir/utils/environment.yml && mamba clean -afy && \
 #    find /mamba/ -follow -type f -name '*.a' -delete && \


### PR DESCRIPTION
Updated XBeam to change compile flags used in GFortran. The `-ftree-parallelize-loops=4` optimisation flag was found to make the beam solver take considerably longer to run than without it. The `-ofast` flag was added as this should increase performance in some cases with no noticeable impact on results.