### PR TITLE
Fixed crv2rotation

### DIFF
--- a/sharpy/utils/algebra.py
+++ b/sharpy/utils/algebra.py
@@ -562,8 +562,8 @@ def crv2rotation(psi):
         skew_normal = skew(normal)
 
         rot_matrix = np.eye(3)
-        rot_matrix += np.sin(norm_psi)*skew_normal
-        rot_matrix += (1.0 - np.cos(norm_psi))*np.dot(skew_normal, skew_normal)
+        rot_matrix += np.sin(norm_psi)/norm_psi*skew_normal
+        rot_matrix += (1.0 - np.cos(norm_psi))/pow(norm_psi, 2)*np.dot(skew_normal, skew_normal)
 
     return rot_matrix
 


### PR DESCRIPTION
Found a bug in the conversion from a $\boldsymbol{\Psi}$ vector to a rotation matrix $\mathbf{R}$. This only applies for larger  $\Psi$ angles, as the small angle correction (which most "normal" cases will use) is correct. 

Intended expression:
$$\mathbf{R} =  \mathbf{I} + \sin||{\boldsymbol{\Psi}||} \tilde{\boldsymbol{\Psi}} + \frac{1-\cos{||\boldsymbol{\Psi}||}}{||\boldsymbol{\Psi}||^2}\tilde{\boldsymbol{\Psi}} \tilde{\boldsymbol{\Psi}}$$

Used expression:
$$\mathbf{R} =  \mathbf{I} + \frac{\sin||\boldsymbol{\Psi}||}{||\boldsymbol{\Psi}||} \tilde{\boldsymbol{\Psi}} + (1-\cos{||\boldsymbol{\Psi}||})\tilde{\boldsymbol{\Psi}} \tilde{\boldsymbol{\Psi}}$$