### PR TITLE
Updated docs to address issue with conda install failing

### DIFF
--- a/docs/source/content/installation.md
+++ b/docs/source/content/installation.md
@@ -1,5 +1,5 @@
 # SHARPy v2.3 Installation Guide
-__Last revision 10 May 2024__
+__Last revision 10 June 2024__
 
 The following step by step tutorial will guide you through the installation process of SHARPy. This is the updated process valid from v2.3.
 
@@ -113,7 +113,17 @@ These are specified in an Anaconda environment that shall be activated prior to 
     ```
     This should take approximately 5 minutes to complete (Tested on Ubuntu 22.04.1). For installation on Apple Silicon, use ```environment_arm64.yml```; this requires GCC and GFortran to be installed prior.
 
-5. Activate the `sharpy` conda environment:
+   Installation using Conda can be memory intensive, and will give the message ```Collecting package metadata (repodata.json): - Killed``` if all the available RAM is filled. From testing, 16GB of total system RAM is reliable for Conda install, whereas 8GB may have issues. Three solutions are available:
+   * Increase available RAM (if running on a compute cluster etc)
+   * Use [Mamba](https://mamba.readthedocs.io/en/latest/), a more efficient drop-in replacement for Conda
+   * Create a blank conda environment and install the required packages:
+     	```bash
+      conda create --name sharpy python=3.10
+      conda config –add channels conda-forge
+      conda install eigen libopenblas libblas libcblas liblapack libgfortran libgcc libgfortran-ng
+      ```
+      
+6. Activate the `sharpy` conda environment:
     ```bash
     conda activate sharpy
     ```


### PR DESCRIPTION
Some users have had an issue with Conda failing whilst creating the environment, giving the following message:
```bash
Collecting package metadata (repodata.json): - Killed
```
This is due to Conda running out of RAM during install, documented [here](https://stackoverflow.com/questions/74566580/why-is-conda-create-env-killed). This is in line with problems found a few months ago, with 8 GB of RAM often not being sufficient. Unfortunately Conda isn't very efficient with memory, and there is little we can do about this. 

 I have updated the docs to include 3 options to fix this issue:
  * Increase available RAM (if running on a compute cluster etc)
   * Use [Mamba](https://mamba.readthedocs.io/en/latest/), a more efficient drop-in replacement for Conda. This is what I personally use locally and find it to be vastly better — however, I can appreciate this isn't an option in some situations!
   * Create a blank conda environment and install the required packages:
     	```bash
      conda create --name sharpy python=3.10
      conda config –add channels conda-forge
      conda install eigen libopenblas libblas libcblas liblapack libgfortran libgcc libgfortran-ng
      ```

Thank you to the students who both found this issue and documented the third fix method!
