### PR TITLE
Temporary Fix for NumPy 2.0 Issues (Main Branch)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,10 +130,10 @@ setup(
     #     ],
     python_requires=">=3.8",
     install_requires=[
-        "numpy",
+        "numpy<2.0",
         "configobj",
         "h5py",
-        "scipy",
+        "scipy<1.14.0",
         "sympy",
         "matplotlib",
         "colorama",


### PR DESCRIPTION
NumPy 2.0 has been released, which depreciates many functions that have been used in SHARPy. This now causes many unit tests to fail, and there is also a corresponding SciPy version which presents issues. This is a temporary fix which sets an upper ceiling on the versions which can be used (was previously set to use latest), however aim to update the code in due course. 