### PR TITLE
Added a plotting utility for aeroelastic modes

### DIFF
--- a/sharpy/linear/src/libss.py
+++ b/sharpy/linear/src/libss.py
@@ -76,6 +76,9 @@ class StateSpace:
         scipy.signal.ltisys.StateSpaceDiscrete
     but supports sparse matrices and other functionalities.
 
+    Gain matrices V and W, and the original state space system have been added as optional parameters, as these
+    are otherwise lost.
+
     Methods:
     - get_mats: return matrices as tuple
     - check_types: check matrices types are supported
@@ -84,7 +87,7 @@ class StateSpace:
     - scale: allows scaling a system
     """
 
-    def __init__(self, A, B, C, D, dt=None):
+    def __init__(self, A, B, C, D, dt=None, *, v=None, w=None, full_system=None):
         """
         Allocate state-space model (A,B,C,D). If dt is not passed, a
         continuous-time system is assumed.
@@ -95,10 +98,13 @@ class StateSpace:
         self.C = C
         self.D = D
         self.dt = dt
+        self.v = v
+        self.w = w
+        self.ss_full = full_system
         self.check_types()
 
         # vector variable tracking
-        self._input_variables = None  # type: LinearVector
+        self._input_variables = None
         self._state_variables = None
         self._output_variables = None
 

--- a/sharpy/postproc/aeroelasticmodeplot.py
+++ b/sharpy/postproc/aeroelasticmodeplot.py
@@ -1,0 +1,276 @@
+import os
+import numpy as np
+from itertools import chain
+from tvtk.api import tvtk, write_data
+
+from sharpy.utils.solver_interface import solver, BaseSolver
+import sharpy.utils.settings as settings_utils
+from sharpy.utils.algebra import crv2rotation, quat2rotation
+from sharpy.utils.cout_utils import cout_wrap
+
+
+@solver
+class AeroelasticModal(BaseSolver):
+    """
+    This class performs modal analysis on a linearised aeroelastic system. The modes are then plotted in phase steps,
+    and the stability eigenvalues printed to the console.
+
+    Note: this does not have support for reduction on the state space model, and also requires a modal projection of the
+    structure.
+    """
+
+    solver_id = 'AeroelasticModal'
+    solver_classification = 'Linear'
+
+    settings_types = dict()
+    settings_default = dict()
+    settings_description = dict()
+
+    settings_types['num_modes'] = 'int'
+    settings_default['num_modes'] = 5
+    settings_description['num_modes'] = 'Number of modes to retain'
+
+    settings_types['use_custom_timestep'] = 'int'
+    settings_default['use_custom_timestep'] = -1
+    settings_description['use_custom_timestep'] = 'Timestep of solution to use for analysis'
+
+    settings_types['step_count'] = 'int'
+    settings_default['step_count'] = 30
+    settings_description['step_count'] = 'Number of phase steps to take along the mode shape'
+
+    settings_types['remove_conjugate'] = 'bool'
+    settings_default['remove_conjugate'] = True
+    settings_description['remove_conjugate'] = 'Remove conjugate modes'
+
+    settings_types['max_rotation_deg'] = 'float'
+    settings_default['max_rotation_deg'] = 25.
+    settings_description['max_rotation_deg'] = 'Scale mode shape to have specified maximum rotation'
+
+    settings_types['max_displacement'] = 'float'
+    settings_default['max_displacement'] = 0.05
+    settings_description['max_displacement'] = 'Scale mode shape to have specified maximum displacement'
+
+    settings_types['max_gamma'] = 'float'
+    settings_default['max_gamma'] = 1.0
+    settings_description['max_gamma'] = 'Scale mode shape to have specified maximum circulation'
+
+    settings_types['save_data'] = 'bool'
+    settings_default['save_data'] = True
+    settings_description['save_data'] = 'Write mode shapes, frequencies and damping to file'
+
+    settings_table = settings_utils.SettingsTable()
+    __doc__ += settings_table.generate(settings_types, settings_default, settings_description)
+
+    def __init__(self):
+        self.data = None
+        self.settings = None
+
+    def initialise(self, data, custom_settings=None, restart=False):
+        self.data = data
+        if custom_settings is None:
+            self.settings = data.settings[self.solver_id]
+        else:
+            self.settings = custom_settings
+        settings_utils.to_custom_types(self.settings,
+                                       self.settings_types,
+                                       self.settings_default)
+
+    def run(self, **kwargs):
+        if not hasattr(self.data, 'linear'):
+            raise AttributeError('Linear data not found')
+
+        a_mat = self.data.linear.ss.A
+
+        state_index = {}
+
+        for var in self.data.linear.ss._state_variables.vector_variables:
+            if var.name in ('gamma', 'gamma_w', 'q'):
+                state_index[var.name] = var.cols_loc
+
+        if len(state_index) != 3:
+            raise ValueError('Missing states from linear system. Ensure that gamma, gamma_w and q are present')
+
+        evals_d_ae, evecs_ae = np.linalg.eig(a_mat)
+        evals_c_ae = np.log(evals_d_ae) / self.data.linear.ss.dt
+
+        if self.settings['remove_conjugate']:
+            first_eig_index = []
+            eig_set = set()
+
+            for i_eig, eig in enumerate(evals_c_ae):
+                eig_pos = eig.real + 1j * np.abs(eig.imag)
+                if eig_pos not in eig_set:
+                    eig_set.add(eig)
+                    first_eig_index.append(i_eig)
+            first_eig_index = np.array(first_eig_index)
+            order = first_eig_index[np.argsort(-evals_c_ae.real[first_eig_index])][:self.settings['num_modes']]
+        else:
+            order = np.argsort(-evals_c_ae.real)[:self.settings['num_modes']]
+
+        # truncated set of aeroelastic modes and eigenvaluesz
+        evals_c_ae_trunc = evals_c_ae[order]
+        evecs_ae_trunc = evecs_ae[:, order]
+
+        # print eigenvalues
+        cout_wrap('Aeroelastic eigenvalues:', 0)
+        for i, eig in enumerate(evals_c_ae_trunc):
+            cout_wrap(f'{i}: {eig:.3f}', 1)
+
+        # return if no data is to be saved
+        if not self.settings['save_data']:
+            return self.data
+
+        # vector of complex phase values to test
+        phase = np.exp(1j * np.linspace(0, 2 * np.pi, self.settings['step_count'], endpoint=False))
+
+        # mode shapes of the structure, as a projection of the free modes
+        num_node = self.data.structure.num_node
+        num_modes_struct = \
+            self.data.structure.timestep_info[self.settings['use_custom_timestep']].modal['eigenvectors'].shape[1]
+
+        struct_evects = np.zeros((6 * num_node, num_modes_struct))
+        struct_evects[6:, :] = self.data.structure.timestep_info[self.settings['use_custom_timestep']].modal[
+            'eigenvectors']
+        node_disp_base = struct_evects @ evecs_ae_trunc[state_index['q'], :]
+
+        # mode shapes of the structural nodes, bound gamma and wake gamma
+        node_disp = np.einsum('ij,k->ijk', node_disp_base, phase).real  # [num_dof, num_lambda, num_phase]
+        gamma = np.vstack((np.einsum('ij,k->ijk', evecs_ae_trunc[state_index['gamma'], :], phase),
+                           np.einsum('ij,k->ijk', evecs_ae_trunc[state_index['gamma_w'], :], phase))).real
+
+        # split structure into displacements and rotations
+        num_dof = node_disp.shape[0]
+        num_node = int(num_dof // 6)
+
+        i_pos = np.array(list(chain([6 * i, 6 * i + 1, 6 * i + 2] for i in range(num_node))))
+        i_rot = np.array(list(chain([6 * i + 3, 6 * i + 4, 6 * i + 5] for i in range(num_node))))
+
+        node_pos = node_disp[i_pos, :, :]
+        node_rot = node_disp[i_rot, :, :]
+
+        # scale mode shapes
+        max_pos = np.max(np.linalg.norm(node_pos, axis=1), axis=(0, 2))
+        node_pos_scaled = np.einsum('ijkl,k->ijkl', node_pos, 1.0 / max_pos) * self.settings['max_displacement']
+
+        max_rot = np.max(np.linalg.norm(node_rot, axis=1), axis=(0, 2))
+        node_rot_scaled = np.einsum('ijkl,k->ijkl', node_rot, 1.0 / max_rot) * np.deg2rad(
+            self.settings['max_rotation_deg'])
+
+        gamma_scale_fact = 1.0 / np.max(np.abs(gamma), axis=(0, 2))
+        gamma_scaled = np.einsum('ijk,j->ijk', gamma, gamma_scale_fact) * self.settings['max_gamma']
+
+        # add structural deflections to linearisation point
+        base_pos = self.data.structure.timestep_info[self.settings['use_custom_timestep']].pos
+
+        # split to give node positions for each surface
+        base_pos_surf = [base_pos[index, :] for index in self.data.aero.aero2struct_mapping]
+
+        psi0 = np.expand_dims(self.data.structure.timestep_info[self.settings['use_custom_timestep']].psi[0, 0, :], 0)
+        psi1 = self.data.structure.timestep_info[self.settings['use_custom_timestep']].psi[:, 1:, :].reshape(-1, 3)
+        base_rot = np.vstack((psi0, psi1))
+
+        combined_beam_pos = (np.broadcast_to(np.expand_dims(base_pos, axis=(2, 3)), shape=node_pos_scaled.shape)
+                             + node_pos_scaled)
+
+        rmat_node_rot = np.apply_along_axis(crv2rotation, 1, node_rot_scaled)
+        rmat_base_rot = np.apply_along_axis(crv2rotation, 1, base_rot)
+
+        # [num_node, 3, 3, num_lambda, num_phase]
+        combined_rmat = np.einsum('ijk,iklmn->ijlmn', rmat_base_rot, rmat_node_rot)
+
+        # in G frame [num_surf, 3, m+1, n+1]
+        zeta_base_g = self.data.aero.timestep_info[self.settings['use_custom_timestep']].zeta
+        zeta_w = self.data.aero.timestep_info[self.settings['use_custom_timestep']].zeta_star
+
+        # rotate to A frame (only works for 1 surface for now)
+        orient_rmat = quat2rotation(self.data.structure.timestep_info[self.settings['use_custom_timestep']].quat)
+
+        # split base rotations to per surface
+        rmat_base_rot_surf = [rmat_base_rot[index, ...] for index in self.data.aero.aero2struct_mapping]
+        combined_rmat_surf = [combined_rmat[index, ...] for index in self.data.aero.aero2struct_mapping]
+        combined_beam_pos_surf = [combined_beam_pos[index, ...] for index in self.data.aero.aero2struct_mapping]
+
+        zeta = []
+        zeta_delta = []
+        is_bound = []
+        surf_number = []
+
+        for i_surf, zeta_base_g in enumerate(zeta_base_g):
+            # [3, m+1, n+1]
+            zeta_base_a = np.einsum('ij,jkl->ikl', orient_rmat.T, zeta_base_g)
+
+            zeta_base_b = np.einsum('ijk,kli->jli', rmat_base_rot_surf[i_surf], zeta_base_a
+                                    - np.broadcast_to(np.expand_dims(base_pos_surf[i_surf].T, 1), zeta_base_a.shape))
+
+            # [n+1, m+1, 3, num_lambda, num_phase]
+            zeta_a = np.einsum('ijklm,jni->inklm', combined_rmat_surf[i_surf], zeta_base_b) + np.expand_dims(
+                combined_beam_pos_surf[i_surf], 1)
+            zeta.append(np.einsum('ij,kljmn->klimn', orient_rmat, zeta_a))
+
+            # [n+1, m+1, num_lambda, num_phase]
+            zeta_delta.append(np.linalg.norm(zeta[-1] - np.expand_dims(np.transpose(zeta_base_g, (2, 1, 0)),
+                                                                       axis=(3, 4)), axis=2))
+
+            is_bound.append(True)
+            surf_number.append(i_surf)
+
+        # add wake data
+        for i_wake, wake in enumerate(zeta_w):
+            zeta.append(np.tile(np.expand_dims(np.transpose(wake, (2, 1, 0)), axis=(3, 4)),
+                                (1, 1, 1, self.settings['num_modes'], self.settings['step_count'])))
+            zeta_delta.append(np.zeros_like(zeta[-1][:, :, 0, ...]))
+            is_bound.append(False)
+            surf_number.append(i_wake)
+
+        # write to file
+        folder = self.data.output_folder + '/aeroelastic_modes/'
+        if not os.path.exists(folder):
+            os.makedirs(folder)
+
+        # write data to file
+        # this has a loop per mode, phase step and surface. Wake panels are here classed as surfaces.
+        for i_mode in range(self.settings['num_modes']):
+            for i_phase in range(self.settings['step_count']):
+                i_state = 0
+                for i_surf in range(len(zeta)):
+                    if is_bound[i_surf]:
+                        filename = folder + f"mode{i_mode:02d}_body_surf{surf_number[i_surf]}_phase{i_phase}.vtu"
+                    else:
+                        filename = folder + f"mode{i_mode:02d}_wake_surf{surf_number[i_surf]}_phase{i_phase}.vtu"
+
+                    n, m = zeta[i_surf].shape[:2]
+
+                    panel_data_dim = (m - 1) * (n - 1)
+
+                    coords = zeta[i_surf][:, :, :, i_mode, i_phase].reshape(-1, 3)
+                    panel_id = np.arange(panel_data_dim)
+                    panel_surf_id = np.full_like(panel_id, i_surf)
+
+                    base_range = np.arange(m - 1)
+                    base_conn = np.concatenate([base_range + i * m for i in range(n - 1)])
+                    conn = np.stack([base_conn, base_conn + 1, base_conn + m + 1, base_conn + m]).T
+
+                    ug = tvtk.UnstructuredGrid(points=coords)
+                    ug.set_cells(tvtk.Quad().cell_type, conn)
+
+                    ug.cell_data.scalars = panel_id
+                    ug.cell_data.scalars.name = 'panel_n_id'
+
+                    ug.cell_data.add_array(
+                        gamma_scaled[i_state:i_state + panel_data_dim, i_mode, i_phase].reshape(m - 1, -1).T.flatten())
+                    ug.cell_data.get_array(1).name = 'gamma'
+
+                    ug.cell_data.add_array(panel_surf_id)
+                    ug.cell_data.get_array(2).name = 'panel_surface_id'
+
+                    ug.point_data.scalars = np.arange(coords.shape[0])
+                    ug.point_data.scalars.name = 'n_id'
+
+                    ug.point_data.add_array(zeta_delta[i_surf][:, :, i_mode, i_phase].ravel())
+                    ug.point_data.get_array(1).name = 'point_displacement_magnitude'
+
+                    write_data(ug, filename)
+
+                    i_state += panel_data_dim
+
+        return self.data

--- a/sharpy/rom/utils/krylovutils.py
+++ b/sharpy/rom/utils/krylovutils.py
@@ -136,14 +136,11 @@ def construct_krylov(r, lu_A, B, approx_type='Pade', side='b'):
         B.shape = (nx, 1)
 
     # Output projection matrices
-    V = np.zeros((nx, r),
-                 dtype=complex)
-    H = np.zeros((r, r),
-                 dtype=complex)
+    V = np.zeros((nx, r), dtype=complex)
+    H = np.zeros((r, r), dtype=complex)
 
     # Declare iterative variables
-    f = np.zeros((nx, r),
-                 dtype=complex)
+    f = np.zeros((nx, r), dtype=complex)
 
     if approx_type == 'partial_realisation':
         A = lu_A
@@ -169,8 +166,7 @@ def construct_krylov(r, lu_A, B, approx_type='Pade', side='b'):
         v = 1 / beta * f[:, j]
 
         V[:, j+1] = v
-        H_hat = np.block([[H[:j+1, :j+1]],
-                          [beta * evec(j)]])
+        H_hat = np.block([[H[:j+1, :j+1]], [beta * evec(j)]])
 
         if approx_type == 'partial_realisation':
             w = A.dot(v)
@@ -258,16 +254,12 @@ def construct_mimo_krylov(r, lu_A_input, B, approx_type='Pade', side='controllab
     m = B.shape[1]  # Full system number of inputs/outputs
     n = B.shape[0]  # Full system number of states
 
-    deflation_tolerance = 1e-4  # Inexact deflation tolerance to approximate norm(V)=0 in machine precision
-
     # Preallocated size may be too large in case columns are deflated
     last_column = 0
 
     # Pre-allocate w, V
     V = np.zeros((n, m * r), dtype=complex)
     w = np.zeros((n, m * r), dtype=complex)  # Initialise w, may be smaller than this due to deflation
-    # V = np.zeros((n, m * r))
-    # w = np.zeros((n, m * r))  # Initialise w, may be smaller than this due to deflation
 
     if approx_type == 'partial_realisation':
         G = B
@@ -281,11 +273,6 @@ def construct_mimo_krylov(r, lu_A_input, B, approx_type='Pade', side='controllab
         ## Orthogonalise w_k to preceding w_j for j < k
         if k >= 1:
             w[:, :k+1] = mgs_ortho(w[:, :k+1])[:, :k+1]
-        # from sharpy.rom.krylov import check_eye
-        # try:
-        #     check_eye(w[:, :k+1], w[:, :k+1].T)
-        # except AssertionError:
-        #     print('failing here - k = %g' % k)
 
 
     V[:, :m+1] = w[:, :m+1]
@@ -294,12 +281,6 @@ def construct_mimo_krylov(r, lu_A_input, B, approx_type='Pade', side='controllab
     mu = m  # Initialise controllability index
     mu_c = m  # Guess at controllability index with no deflation
     t = m   # worked column index
-
-    # from sharpy.rom.krylov import check_eye
-    # try:
-    #     check_eye(V[:, :m+1], V[:, :m+1].T)
-    # except AssertionError:
-    #     print('failing here')
 
     for k in range(1, r):
         for j in range(mu_c):
@@ -311,17 +292,6 @@ def construct_mimo_krylov(r, lu_A_input, B, approx_type='Pade', side='controllab
             # Orthogonalise w[:,t] against V_i -
             w[:, :t+1] = mgs_ortho(w[:, :t+1])[:, :t+1]
 
-            # if np.linalg.norm(w[:, t]) < deflation_tolerance:
-            #     # Deflate w_k
-            #     cout.cout_wrap('\tVector deflated', 3)
-            #     w = [w[:, 0:t], w[:, t+1:]]
-            #     last_column -= 1
-            #     mu -= 1
-            # else:
-            #     pass
-            #     # V[:, t] = w[:, t]
-            #     # last_column += 1
-            #     # t += 1
             try:
                 check_eye(w[:, :t+1], w[:, :t+1].T)
                 V[:, t] = w[:, t]
@@ -415,12 +385,6 @@ def schur_ordered(A, ct=False):
     else:
         sort_eigvals = 'iuc'
 
-    # if A.dtype == complex:
-    #     output_form = 'complex'
-    # else:
-    #     output_form = 'real'
-    # issues when not using the complex form of the Schur decomposition
-
     output_form = 'complex'
     As, Tt, n_stable1 = sclalg.schur(A, output=output_form, sort=sort_eigvals)
 
@@ -478,8 +442,6 @@ def remove_a12(As, n_stable):
 
     T = np.block([[np.eye(n_stable), -X], [np.zeros((n-n_stable, n_stable)), np.eye(n-n_stable)]])
 
-    T2 = np.eye(n, n_stable)
-    # App = T2.T.dot(T.dot(As.dot(np.linalg.inv(T).dot(T2))))
     return T, X
 
 

--- a/sharpy/structure/utils/modalutils.py
+++ b/sharpy/structure/utils/modalutils.py
@@ -7,14 +7,14 @@ from tvtk.api import tvtk, write_data
 def frequency_damping(eigenvalue):
     omega_n = np.abs(eigenvalue)
     omega_d = np.abs(eigenvalue.imag)
-    f_n = omega_n / 2 / np.pi
-    f_d = omega_d / 2 / np.pi
+    f_n = omega_n / 2.0 / np.pi
+    f_d = omega_d / 2.0 / np.pi
     if f_d < 1e-8:
-        damping_ratio = 1.
+        damping_ratio = 1.0
         period = np.inf
     else:
         damping_ratio = -eigenvalue.real / omega_n
-        period = 1 / f_d
+        period = 1.0 / f_d
 
     return omega_n, omega_d, damping_ratio, f_n, f_d, period
 


### PR DESCRIPTION
This includes a new  ```AeroelasticModal``` post processor which plots the aeroelastic modes, found from the linearised aeroelastic system. Whilst looking at the aeroelastic eigenvalues is useful for determining stability, this post processor is useful for investigating what the modes look like, which can be hard to interpret from a vector of complex numbers!

The output is similar to the ```Modal``` solver which plots the natural modes of the structure projected onto the aerodynamic grid as VTK files, however this here also includes the aerodynamic gamma terms for both the bound wing panels and the wake. As there is a phase component in the aeroelastic eigenvectors, I have included the ability to plot at evenly spaced points, which gives an animation of what the mode looks like. Please enjoy an example gif of the output below for the Pazy wing, however I have also validated it for the FLEXOP with more aerodynamic surfaces.

![swept_pazy_flutter_cropped](https://github.com/user-attachments/assets/b6d2b295-9490-4fc5-8db0-47cddb69fffc)

To keep it compatible with the Krylov reduction (allowing for much faster analysis) I was required to make small changes to the linear system source code, only so that gain matrices are propagated to the post processor as well as information about the original linear system states. It can be very interesting to see what aerodynamic features the Krylov likes to keep, and what it discards. I increased the default Krylov order from 1 to 4, because 1 usually gives very poor results. 

I also removed some unused code here - the functionality of this solver should however be as before. 

