### PR TITLE
Hotfix for pypi github action

### DIFF
--- a/.github/workflows/pypi_build.yaml
+++ b/.github/workflows/pypi_build.yaml
@@ -10,8 +10,10 @@ on:
     branches: 
       - develop
       - main
+      - dev_pypipatch
     paths:
       - 'setup.py'
+      - 'pyproject.toml'
       - '.github/workflows/pypi*'  
   pull_request:
     branches:
@@ -23,7 +25,7 @@ jobs:
   create-pypi-image:
     name: >-
       Create .whl 🛞 from SHARPy distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       python-version-chosen: "3.10.8"
     permissions:
@@ -39,7 +41,7 @@ jobs:
       - name: Set up GCC
         uses: egor-tensin/setup-gcc@v1
         with:
-          version: 7
+          version: 9
           platform: x64
       - name: Pre-Install dependencies
         run: |
@@ -55,10 +57,12 @@ jobs:
           --user    
       - name: Install wheel
         run: python3 -m pip install wheel --user
+      - name: Install depen
+        run: python3 -m pip install setuptools_scm
       - name: Build a source tarball
-        run: python setup.py sdist
-      - name: Build a binary wheel
-        run: python3 setup.py bdist_wheel        
+        run: python -m build --sdist
+      - name: Build a source tarball
+        run: python -m build --wheel        
       - name: Find the wheel created during pip install
         run: 
           python3 -m pip cache dir
@@ -67,11 +71,18 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+      - name: Github logs for rebug
+        run: |
+            echo "::group::Logs" 
+            echo ${{ github.event_name }}
+            echo ${{ github.event.action }}
+            echo '${{ toJson(github) }}'
+            echo "::endgroup::"     
 
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: github.event_name == 'release' && github.event.release.action == 'published'   # only publish to PyPI on tag pushes
+    if: github.event_name == 'release' && github.event.action == 'published'   # only publish to PyPI on published release
     needs:
     - create-pypi-image
     runs-on: ubuntu-latest

--- a/pypi_compatible_build.py
+++ b/pypi_compatible_build.py
@@ -1,0 +1,49 @@
+"""
+To enable git dependencies for pypi package - referencing link below
+https://stackoverflow.com/questions/54887301/how-can-i-use-git-repos-as-dependencies-for-my-pypi-package
+"""
+
+from io import StringIO
+from typing import TextIO
+
+import setuptools
+from packaging.metadata import Metadata
+from setuptools._core_metadata import _write_requirements  # type: ignore[import-not-found]
+from setuptools.build_meta import *  # noqa: F403
+
+
+def write_pypi_compatible_requirements(self: Metadata, final_file: TextIO) -> None:
+    """Mark requirements with URLs as external."""
+    print("abcd")
+    initial_file = StringIO()
+    _write_requirements(self, initial_file)
+    initial_file.seek(0)
+    for initial_line in initial_file:
+        final_line = initial_line
+        metadata = Metadata.from_email(initial_line, validate=False)
+        if metadata.requires_dist and metadata.requires_dist[0].url:
+            final_line = initial_line.replace('Requires-Dist:', 'Requires-External:')
+        final_file.write(final_line)
+
+setuptools._core_metadata._write_requirements = write_pypi_compatible_requirements
+
+"""For emulating default build-backend = "setuptools.build_meta" """
+
+from setuptools.build_meta import build_wheel as setuptools_build_wheel
+from setuptools.build_meta import build_sdist as setuptools_build_sdist
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    # Custom behavior before building the wheel
+    result = setuptools_build_wheel(
+        wheel_directory,
+        config_settings=config_settings,
+        metadata_directory=metadata_directory,
+    )
+    # Custom behavior after building the wheel
+    return result
+
+def build_sdist(sdist_directory, config_settings=None):
+    # Custom behavior before building the sdist
+    result = setuptools_build_sdist(sdist_directory, config_settings)
+    # Custom behavior after building the sdist
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,72 @@
 [build-system]
 requires = [
-    "setuptools",
+    'setuptools>=61.0',
     #"scikit-build>=0.13",
-    "cmake>=3.14.3"
+    'cmake>=3.14.3',
+    'setuptools_scm[toml]>=6.2',
+    'wheel'
     ]
+build-backend = 'pypi_compatible_build'
+backend-path = ['']
+
+[project]
+name = "ic_sharpy"
+dynamic = ["version", "description", "readme", "requires-python", "license", "keywords", "classifiers", "scripts", "dependencies", "optional-dependencies"]
+
+## Uncomment below and remove 'dynamic' if we decommission setup.py in the future for pyproject.toml 
+
+# description = "SHARPy is a nonlinear aeroelastic analysis package developed at Imperial College London."
+# readme = "README.md"
+# license = { text = "BSD-3-Clause" }
+# keywords = ["nonlinear", "aeroelastic", "structural", "aerodynamic", "analysis"]
+# requires-python = ">=3.8"
+# dependencies = [
+#     "numpy<2.0",
+#     "configobj",
+#     "h5py",
+#     "scipy<1.14.0",
+#     "sympy",
+#     "matplotlib",
+#     "colorama",
+#     "dill",
+#     "jupyterlab",
+#     "mayavi @ git+https://github.com/enthought/mayavi.git",
+#     "pandas",
+#     "control",
+#     "openpyxl>=3.0.10",
+#     "lxml>=4.4.1",
+#     "PySocks",
+#     "PyYAML",
+#     "jax"
+# ]
+# classifiers = [
+#     "Operating System :: MacOS",
+#     "Operating System :: POSIX :: Linux",
+#     "Programming Language :: Python :: 3.10",
+#     "Programming Language :: Fortran",
+#     "Programming Language :: C++"
+# ]
+
+# [project.optional-dependencies]
+# docs = [
+#     "sphinx",
+#     "recommonmark>=0.6.0",
+#     "sphinx_rtd_theme>=0.4.3",
+#     "nbsphinx>=0.4.3"
+# ]
+# all = [
+#     "sphinx",
+#     "recommonmark>=0.6.0",
+#     "sphinx_rtd_theme>=0.4.3",
+#     "nbsphinx>=0.4.3"
+# ]
+
+# [project.urls]
+# Homepage = "https://github.com/ImperialCollegeLondon/sharpy"
+
+# [project.scripts]
+# sharpy = "sharpy.sharpy_main:sharpy_run"
+
+## [tool.setuptools.packages.find]
+## where = [".", "lib"]
+## include = ["sharpy", "uvlm", "xbeam"]


### PR DESCRIPTION
As titled, also includes update to pyproject.toml for potentially replacing the setup.py build process - tested with [act](https://nektosact.com/) and github action runners.

Issue being addressed is the mayavi direct dependency for pypi uploads - https://stackoverflow.com/questions/54887301/how-can-i-use-git-repos-as-dependencies-for-my-pypi-package