### PR TITLE
Update linearassembler.py

### DIFF
--- a/sharpy/solvers/linearassembler.py
+++ b/sharpy/solvers/linearassembler.py
@@ -7,6 +7,8 @@ from sharpy.utils.solver_interface import solver, BaseSolver
 import sharpy.linear.utils.ss_interface as ss_interface
 import sharpy.utils.settings as settings_utils
 import sharpy.utils.cout_utils as cout
+import sharpy.linear.assembler
+import sharpy.rom
 
 
 @solver


### PR DESCRIPTION
V2.4 breakes the LinearAeroelastic tests, since the solver is not imported. This pull request restores the working environment for linear simulations by importing the correct solver