### PR TITLE
Remove requirement for Mayavi for building SHARPy.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,9 +139,6 @@ setup(
         "colorama",
         "dill",
         "jupyterlab",
-        #"mayavi",
-        # Fix for tvtk issue, see Issue #313 - darn thing can't be found
-        "mayavi @ git+https://github.com/enthought/mayavi.git",
         "pandas",
         "control",
         "openpyxl>=3.0.10",
@@ -149,6 +146,7 @@ setup(
         "PySocks",
         "PyYAML",
         "jax",
+        "vtk",
     ],
     extras_require={
         "docs": [

--- a/sharpy/generators/gridbox.py
+++ b/sharpy/generators/gridbox.py
@@ -3,7 +3,6 @@ import numpy as np
 import sharpy.utils.generator_interface as generator_interface
 import sharpy.utils.settings as settings
 import numpy as np
-from tvtk.api import tvtk, write_data
 import ctypes as ct
 import copy
 
@@ -82,7 +81,7 @@ class GridBox(generator_interface.BaseGenerator):
                     grid[iz][1, ix, iy] = yarray[iy]
                     grid[iz][2, ix, iy] = zarray[iz]
 
-
+        from tvtk.api import tvtk
         vtk_info = tvtk.RectilinearGrid()
         vtk_info.dimensions = np.array([nx, ny, nz], dtype=int)
         vtk_info.x_coordinates = xarray

--- a/sharpy/postproc/aerogridplot.py
+++ b/sharpy/postproc/aerogridplot.py
@@ -2,9 +2,7 @@ import os
 
 import numpy as np
 
-import sharpy.utils.algebra as algebra
 import sharpy.utils.cout_utils as cout
-from sharpy.utils.settings import str2bool
 from sharpy.utils.solver_interface import solver, BaseSolver
 import sharpy.utils.settings as su
 import sharpy.aero.utils.uvlmlib as uvlmlib
@@ -315,6 +313,7 @@ class AerogridPlot(BaseSolver):
                     panel_surf_id[counter] = i_surf
                     panel_sigma[counter] = nonlifting_tstep.sigma[i_surf][i_m, i_n]
 
+            from tvtk.api import tvtk, write_data
             ug = tvtk.UnstructuredGrid(points=coords)
             ug.set_cells(tvtk.Quad().cell_type, conn)
             ug.cell_data.scalars = panel_id

--- a/sharpy/postproc/cleanup.py
+++ b/sharpy/postproc/cleanup.py
@@ -1,8 +1,3 @@
-import os
-
-import numpy as np
-from tvtk.api import tvtk, write_data
-
 from sharpy.utils.solver_interface import solver, BaseSolver
 import sharpy.utils.settings as settings_utils
 

--- a/sharpy/postproc/plotflowfield.py
+++ b/sharpy/postproc/plotflowfield.py
@@ -1,6 +1,5 @@
 import os
 import numpy as np
-from tvtk.api import tvtk, write_data
 from sharpy.utils.solver_interface import solver, BaseSolver
 import sharpy.utils.generator_interface as gen_interface
 import sharpy.utils.settings as settings_utils
@@ -180,6 +179,7 @@ class PlotFlowField(BaseSolver):
         array_counter += 1
 
         filename = self.folder + "VelocityField_" + '%06u' % ts + ".vtk"
+        from tvtk.api import write_data
         write_data(vtk_info, filename)
 
     def run(self, **kwargs):

--- a/utils/environment.yml
+++ b/utils/environment.yml
@@ -9,8 +9,7 @@ dependencies:
   - dill>=0.3.1.1          
   - h5py>=2.9.0            
   - jupyterlab>=1.2.3      
-  - lxml>=4.4.1            
-  - mayavi>=4.7.1          
+  - lxml>=4.4.1
   - nbsphinx>=0.4.3        
   - pandas>=0.25.3         
   - pyOpenSSL>=19.0.0      


### PR DESCRIPTION
Mayavi is now considered un-maintained, and as it has again broken the install process I have depreciated it. All core plotting routines (modal, aero grid and beam) no longer depend upon this and should not be affected. There is still some legacy code referring to it - I have changed this code to use local imports to prevent issues at import time.